### PR TITLE
Security updates, race fix, /setup validation and daily recaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@ APP_ID=<APP_ID>
 DISCORD_TOKEN=<DISCORD_TOKEN>
 PUBLIC_KEY=<PUBLIC_KEY>
 
+# Optional: set during dev to register commands instantly in one guild
+# instead of globally (global can take up to an hour to propagate).
+# GUILD_ID=<GUILD_ID>
+
 POSTGRES_USER=pushup
 POSTGRES_PASSWORD=change_me
 POSTGRES_DB=pushup_challenge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+Discord bot (discord.js v14, Node >= 22.12, pure ESM) tracking per-guild exercise challenges. Data in Postgres via Drizzle ORM.
+
+## Commands
+
+- Every script loads env via `node --env-file=.env` (no dotenv package). Bare `node src/index.js` fails; use npm scripts or add the flag yourself.
+- `npm run start` — run the bot locally
+- `npm run deploy` — register slash commands with Discord (global, not guild-scoped; new/changed commands don't appear until this runs)
+- `npm run db:push` — apply `src/db/schema.js` directly to Postgres. The workflow is push-based: there is no `drizzle/` migrations folder and no generate/migrate scripts.
+- No test suite and no lint script. Verification = `npx eslint .` (Prettier runs inside ESLint as `prettier/prettier: error`).
+- For dev, set `GUILD_ID` in `.env` before `npm run deploy` to register commands instantly in one guild; without it registration is global and takes up to an hour to propagate.
+
+## Architecture
+
+- Slash commands auto-load at startup from `src/commands/<group>/*.js`; each file must export `data` (SlashCommandBuilder) and `execute`, optionally `cooldown` (seconds, default 3). Events auto-load from `src/events/*.js` exporting `name`, `execute`, optional `once`.
+- All DB access goes through `src/db/queries.js` (Drizzle, schema in `src/db/schema.js`). Query functions return `{ ok, reason }` result objects that each command maps to user-facing messages.
+- Count mutations run in a transaction with `SELECT ... FOR UPDATE` on the entry row — keep that pattern or concurrent commands lose updates.
+- Daily recaps: `src/scheduler.js` is started from the ready event and ticks every minute; a guild gets its recap when guild-timezone `HH:mm` equals `reminderTime`, `lastRecapDate ≠ today`, and today is within `startDate + durationDays`.
+
+## Conventions / gotchas
+
+- Relative imports need the `.js` extension (ESM).
+- Formatting is enforced, not optional: 4-space indent, single quotes, semicolons, trailing commas, 80 cols. Run `npx eslint .` before finishing.
+- User-facing strings are French using typographic apostrophes (’). Match existing command files.
+- Exercise types live in `EXERCISE_TYPES` in `src/db/schema.js` (a PG enum — changing it requires `db:push`); `/log` and `/admin-log` choices derive from it automatically.
+- Daily entry dates are computed in the guild's timezone (Luxon, default `Europe/Paris`), not server time — see `dateInGuildTimezone` in `queries.js`.
+
+## Environment / deployment
+
+- `.env.example`'s `DATABASE_URL` points at the compose hostname `db`. Running npm scripts on the host against the compose Postgres (port 5432 published) needs `localhost` instead.
+- Production flow (README): build image → `docker compose run --rm bot node src/deploy-commands.js` → `up -d`. Inside the container, `src/start_bot.sh` redeploys commands and retries `drizzle-kit push` until the DB is up before starting the bot.
+- The only remaining `npm audit` finding is esbuild via drizzle-kit's CLI config loader — dev-only, no server exposed; don't "fix" it by downgrading drizzle-kit.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN chmod +x src/start_bot.sh
 
 ENV NODE_ENV=production
 
+USER node
+
 CMD ["src/start_bot.sh"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,7 @@
 services:
     bot:
         build: .
+        restart: unless-stopped
         environment:
             APP_ID: ${APP_ID}
             DISCORD_TOKEN: ${DISCORD_TOKEN}
@@ -11,6 +12,7 @@ services:
 
     db:
         image: postgres:17-alpine
+        restart: unless-stopped
         environment:
             POSTGRES_USER: ${POSTGRES_USER}
             POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "discord.js": "^14.26.4",
+                "discord.js": "^14.27.0",
                 "drizzle-orm": "^0.45.2",
                 "luxon": "^3.7.2",
                 "node-cron": "^4.2.1",
@@ -18,12 +18,10 @@
             "devDependencies": {
                 "@eslint/js": "^10.0.1",
                 "drizzle-kit": "^0.31.10",
-                "eslint": "^10.5.0",
-                "eslint-plugin-eslint-comments": "^3.2.0",
-                "eslint-plugin-jest": "^29.15.2",
+                "eslint": "^10.9.1",
                 "eslint-plugin-prettier": "^5.5.6",
-                "globals": "^17.6.0",
-                "prettier": "^3.8.4"
+                "globals": "^17.11.0",
+                "prettier": "^3.9.6"
             },
             "engines": {
                 "node": ">=22.12.0"
@@ -75,9 +73,9 @@
             }
         },
         "node_modules/@discordjs/rest": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
-            "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.3.tgz",
+            "integrity": "sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@discordjs/collection": "^2.1.1",
@@ -85,10 +83,10 @@
                 "@sapphire/async-queue": "^1.5.3",
                 "@sapphire/snowflake": "^3.5.5",
                 "@vladfrangu/async_event_emitter": "^2.4.6",
-                "discord-api-types": "^0.38.40",
+                "discord-api-types": "^0.38.50",
                 "magic-bytes.js": "^1.13.0",
                 "tslib": "^2.6.3",
-                "undici": "6.24.1"
+                "undici": "^6.27.0"
             },
             "engines": {
                 "node": ">=18"
@@ -107,16 +105,6 @@
             },
             "funding": {
                 "url": "https://github.com/discordjs/discord.js?sponsor"
-            }
-        },
-        "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
-            "version": "3.5.5",
-            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
-            "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=v14.0.0",
-                "npm": ">=7.0.0"
             }
         },
         "node_modules/@discordjs/util": {
@@ -1112,9 +1100,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-            "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+            "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1285,9 +1273,9 @@
             }
         },
         "node_modules/@sapphire/snowflake": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-            "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+            "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=v14.0.0",
@@ -1331,147 +1319,6 @@
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
-            }
-        },
-        "node_modules/@typescript-eslint/project-service": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
-            "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.61.1",
-                "@typescript-eslint/types": "^8.61.1",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
-            "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.61.1",
-                "@typescript-eslint/visitor-keys": "8.61.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
-            "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/types": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
-            "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
-            "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.61.1",
-                "@typescript-eslint/tsconfig-utils": "8.61.1",
-                "@typescript-eslint/types": "8.61.1",
-                "@typescript-eslint/visitor-keys": "8.61.1",
-                "debug": "^4.4.3",
-                "minimatch": "^10.2.2",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.5.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/utils": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
-            "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.61.1",
-                "@typescript-eslint/types": "8.61.1",
-                "@typescript-eslint/typescript-estree": "8.61.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
-            "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.61.1",
-                "eslint-visitor-keys": "^5.0.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@vladfrangu/async_event_emitter": {
@@ -1535,16 +1382,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/buffer-from": {
@@ -1595,33 +1442,33 @@
             "license": "MIT"
         },
         "node_modules/discord-api-types": {
-            "version": "0.38.48",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.48.tgz",
-            "integrity": "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ==",
+            "version": "0.38.53",
+            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.53.tgz",
+            "integrity": "sha512-HL1zz/UuZ+bbJjA/X8Kbxx9gk8v9rJAbTeWRNYKmIdjwJ7EovjlHgoJTxcLpATfNJ+AonOtMdy3Y5MVIJAAd/A==",
             "license": "MIT",
             "workspaces": [
                 "scripts/actions/documentation"
             ]
         },
         "node_modules/discord.js": {
-            "version": "14.26.4",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
-            "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
+            "version": "14.27.0",
+            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
+            "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@discordjs/builders": "^1.14.1",
                 "@discordjs/collection": "1.5.3",
                 "@discordjs/formatters": "^0.6.2",
-                "@discordjs/rest": "^2.6.1",
+                "@discordjs/rest": "^2.6.2",
                 "@discordjs/util": "^1.2.0",
                 "@discordjs/ws": "^1.2.3",
-                "@sapphire/snowflake": "3.5.3",
-                "discord-api-types": "^0.38.40",
+                "@sapphire/snowflake": "3.5.5",
+                "discord-api-types": "^0.38.49",
                 "fast-deep-equal": "3.1.3",
                 "lodash.snakecase": "4.1.1",
                 "magic-bytes.js": "^1.13.0",
                 "tslib": "^2.6.3",
-                "undici": "6.24.1"
+                "undici": "^6.27.0"
             },
             "engines": {
                 "node": ">=18"
@@ -1827,9 +1674,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-            "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+            "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -1839,7 +1686,7 @@
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
                 "@eslint/config-array": "^0.23.5",
-                "@eslint/config-helpers": "^0.6.0",
+                "@eslint/config-helpers": "^0.7.0",
                 "@eslint/core": "^1.2.1",
                 "@eslint/plugin-kit": "^0.7.2",
                 "@humanfs/node": "^0.16.6",
@@ -1863,7 +1710,7 @@
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "minimatch": "^10.2.4",
+                "minimatch": "^10.2.5",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3"
             },
@@ -1881,66 +1728,6 @@
             },
             "peerDependenciesMeta": {
                 "jiti": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/eslint-plugin-eslint-comments": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
-            "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "escape-string-regexp": "^1.0.5",
-                "ignore": "^5.0.5"
-            },
-            "engines": {
-                "node": ">=6.5.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            },
-            "peerDependencies": {
-                "eslint": ">=4.19.1"
-            }
-        },
-        "node_modules/eslint-plugin-eslint-comments/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/eslint-plugin-jest": {
-            "version": "29.15.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
-            "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/utils": "^8.0.0"
-            },
-            "engines": {
-                "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/eslint-plugin": "^8.0.0",
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "jest": "*",
-                "typescript": ">=4.8.4 <7.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@typescript-eslint/eslint-plugin": {
-                    "optional": true
-                },
-                "jest": {
-                    "optional": true
-                },
-                "typescript": {
                     "optional": true
                 }
             }
@@ -2099,24 +1886,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2210,9 +1979,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "17.6.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-            "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+            "version": "17.11.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+            "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2469,19 +2238,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/postgres": {
             "version": "3.4.9",
             "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.9.tgz",
@@ -2506,9 +2262,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-            "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2552,19 +2308,6 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-            }
-        },
-        "node_modules/semver": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-            "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/shebang-command": {
@@ -2625,36 +2368,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/synckit"
-            }
-        },
-        "node_modules/tinyglobby": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/ts-api-utils": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
-            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.12"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4"
             }
         },
         "node_modules/ts-mixer": {
@@ -3185,25 +2898,10 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/typescript": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peer": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
-            }
-        },
         "node_modules/undici": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-            "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -20,12 +20,10 @@
     "scripts": {
         "start": "node --env-file=.env src/index.js",
         "deploy": "node --env-file=.env src/deploy-commands.js",
-        "db:push": "node --env-file=.env ./node_modules/drizzle-kit/bin.cjs push",
-        "db:generate": "node --env-file=.env ./node_modules/drizzle-kit/bin.cjs generate",
-        "db:migrate": "node --env-file=.env ./node_modules/drizzle-kit/bin.cjs migrate"
+        "db:push": "node --env-file=.env ./node_modules/drizzle-kit/bin.cjs push"
     },
     "dependencies": {
-        "discord.js": "^14.26.4",
+        "discord.js": "^14.27.0",
         "drizzle-orm": "^0.45.2",
         "luxon": "^3.7.2",
         "node-cron": "^4.2.1",
@@ -34,11 +32,9 @@
     "devDependencies": {
         "@eslint/js": "^10.0.1",
         "drizzle-kit": "^0.31.10",
-        "eslint": "^10.5.0",
-        "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-jest": "^29.15.2",
+        "eslint": "^10.9.1",
         "eslint-plugin-prettier": "^5.5.6",
-        "globals": "^17.6.0",
-        "prettier": "^3.8.4"
+        "globals": "^17.11.0",
+        "prettier": "^3.9.6"
     }
 }

--- a/src/commands/admin/setup.js
+++ b/src/commands/admin/setup.js
@@ -4,7 +4,10 @@ import {
     PermissionFlagsBits,
     SlashCommandBuilder,
 } from 'discord.js';
+import { DateTime } from 'luxon';
 import { setupGuild } from '../../db/queries.js';
+
+const reminderTimePattern = /^([01]\d|2[0-3]):[0-5]\d$/;
 
 export const data = new SlashCommandBuilder()
     .setName('setup')
@@ -52,6 +55,22 @@ export async function execute(interaction) {
         interaction.options.getString('timezone') ?? 'Europe/Paris';
     const reminderTime =
         interaction.options.getString('reminder_time') ?? '20:00';
+
+    if (!DateTime.now().setZone(timezone).isValid) {
+        await interaction.reply({
+            content: `Fuseau horaire invalide : \`${timezone}\`. Utilise un nom IANA comme \`Europe/Paris\`.`,
+            flags: MessageFlags.Ephemeral,
+        });
+        return;
+    }
+
+    if (!reminderTimePattern.test(reminderTime)) {
+        await interaction.reply({
+            content: `Heure de rappel invalide : \`${reminderTime}\`. Format attendu : \`HH:mm\`.`,
+            flags: MessageFlags.Ephemeral,
+        });
+        return;
+    }
 
     await setupGuild({
         guildId: interaction.guildId,

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -1,4 +1,4 @@
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import { db } from './client.js';
 import {
@@ -124,34 +124,52 @@ async function applyExerciseChange({
         entryDate,
         exerciseType,
     );
-    const beforeCount = entry.count;
-    let afterCount;
 
-    if (action === 'add' || action === 'admin_add') {
-        afterCount = beforeCount + amount;
-    } else if (action === 'remove' || action === 'admin_remove') {
-        afterCount = Math.max(beforeCount - amount, 0);
-    } else {
-        afterCount = amount;
-    }
+    // Lock the row so concurrent commands cannot lose updates.
+    const { updatedEntry, beforeCount, afterCount } = await db.transaction(
+        async (tx) => {
+            const [locked] = await tx
+                .select({ count: entries.count })
+                .from(entries)
+                .where(eq(entries.id, entry.id))
+                .for('update');
 
-    const [updatedEntry] = await db
-        .update(entries)
-        .set({
-            count: afterCount,
-            updatedAt: new Date(),
-        })
-        .where(eq(entries.id, entry.id))
-        .returning();
+            const previousCount = locked.count;
+            let nextCount;
 
-    await db.insert(entryEvents).values({
-        entryId: entry.id,
-        actorUserId,
-        action,
-        amount,
-        beforeCount,
-        afterCount,
-    });
+            if (action === 'add' || action === 'admin_add') {
+                nextCount = previousCount + amount;
+            } else if (action === 'remove' || action === 'admin_remove') {
+                nextCount = Math.max(previousCount - amount, 0);
+            } else {
+                nextCount = amount;
+            }
+
+            const [changedEntry] = await tx
+                .update(entries)
+                .set({
+                    count: nextCount,
+                    updatedAt: new Date(),
+                })
+                .where(eq(entries.id, entry.id))
+                .returning();
+
+            await tx.insert(entryEvents).values({
+                entryId: entry.id,
+                actorUserId,
+                action,
+                amount,
+                beforeCount: previousCount,
+                afterCount: nextCount,
+            });
+
+            return {
+                updatedEntry: changedEntry,
+                beforeCount: previousCount,
+                afterCount: nextCount,
+            };
+        },
+    );
 
     return {
         ok: true,
@@ -416,4 +434,77 @@ export async function getUserStats(guildId, userId, exerciseType) {
         );
 
     return { ok: true, stats };
+}
+
+// --- Daily recap ---
+function isRecapDue(guild) {
+    const now = DateTime.now().setZone(guild.timezone);
+    const today = now.toISODate();
+
+    if (guild.lastRecapDate === today) {
+        return false;
+    }
+
+    if (now.toFormat('HH:mm') !== guild.reminderTime) {
+        return false;
+    }
+
+    if (guild.startDate) {
+        const lastDay = DateTime.fromISO(guild.startDate, {
+            zone: guild.timezone,
+        })
+            .plus({ days: guild.durationDays - 1 })
+            .toISODate();
+
+        if (today > lastDay) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+export async function getDueRecapGuilds() {
+    const configuredGuilds = await db
+        .select()
+        .from(guilds)
+        .where(isNotNull(guilds.trackedChannelId));
+
+    return configuredGuilds.filter(isRecapDue);
+}
+
+export async function getDailyProgress(guild) {
+    const entryDate = dateInGuildTimezone(guild);
+    const total = sql`coalesce(sum(${entries.count}), 0)`.mapWith(Number);
+
+    const rows = await db
+        .select({
+            userId: participants.userId,
+            total,
+        })
+        .from(participants)
+        .leftJoin(
+            entries,
+            and(
+                eq(entries.participantId, participants.id),
+                eq(entries.entryDate, entryDate),
+            ),
+        )
+        .where(
+            and(
+                eq(participants.guildId, guild.guildId),
+                eq(participants.active, true),
+            ),
+        )
+        .groupBy(participants.userId)
+        .orderBy(desc(total));
+
+    return { entryDate, rows };
+}
+
+export async function markRecapSent(guildId, recapDate) {
+    await db
+        .update(guilds)
+        .set({ lastRecapDate: recapDate })
+        .where(eq(guilds.guildId, guildId));
 }

--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -7,7 +7,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const token = process.env.DISCORD_TOKEN;
 const clientId = process.env.APP_ID;
-// const guildId = '775425543243956297'; // 'Serveur de test'
+// Optional: set GUILD_ID to register instantly in one guild (dev) instead of
+// globally, which can take up to an hour to propagate.
+const guildId = process.env.GUILD_ID;
 
 const commands = [];
 const foldersPath = path.join(__dirname, 'commands');
@@ -34,14 +36,16 @@ for (const folder of commandFolders) {
 const rest = new REST().setToken(token);
 
 try {
+    const route = guildId
+        ? Routes.applicationGuildCommands(clientId, guildId)
+        : Routes.applicationCommands(clientId);
+
     console.log(
-        `Started refreshing ${commands.length} application (/) commands.`,
+        `Started refreshing ${commands.length} application (/) commands${
+            guildId ? ` in guild ${guildId}` : ' globally'
+        }.`,
     );
-    const data = await rest.put(
-        // Routes.applicationGuildCommands(clientId, guildId),
-        Routes.applicationCommands(clientId),
-        { body: commands },
-    );
+    const data = await rest.put(route, { body: commands });
     console.log(
         `Successfully reloaded ${data.length} application (/) commands.`,
     );

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -35,7 +35,7 @@ export async function execute(interaction) {
             if (now < expirationTime) {
                 const expiredTimestamp = Math.round(expirationTime / 1_000);
                 return interaction.reply({
-                    content: `Please wait, you are on a cooldown for \`${command.data.name}\`. You can use it again <t:${expiredTimestamp}:R>.`,
+                    content: `Patiente un peu, \`${command.data.name}\` est en cooldown. Réutilisable <t:${expiredTimestamp}:R>.`,
                     flags: MessageFlags.Ephemeral,
                 });
             }
@@ -54,12 +54,14 @@ export async function execute(interaction) {
             console.error(error);
             if (interaction.replied || interaction.deferred) {
                 await interaction.followUp({
-                    content: 'There was an error while executing this command!',
+                    content:
+                        'Une erreur est survenue pendant l’exécution de cette commande !',
                     flags: MessageFlags.Ephemeral,
                 });
             } else {
                 await interaction.reply({
-                    content: 'There was an error while executing this command!',
+                    content:
+                        'Une erreur est survenue pendant l’exécution de cette commande !',
                     flags: MessageFlags.Ephemeral,
                 });
             }

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -1,8 +1,10 @@
 import { Events } from 'discord.js';
+import { startScheduler } from '../scheduler.js';
 
 export const name = Events.ClientReady;
 export const once = true;
 
 export async function execute(client) {
+    startScheduler(client);
     console.log(`Ready! Logged in as ${client.user.tag}`);
 }

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -1,0 +1,48 @@
+import cron from 'node-cron';
+import {
+    getDailyProgress,
+    getDueRecapGuilds,
+    markRecapSent,
+} from './db/queries.js';
+
+function buildRecapMessage(guild, progress) {
+    const lines = progress.rows.map((row) => {
+        const status =
+            row.total >= guild.dailyGoal
+                ? 'objectif atteint !'
+                : 'objectif non atteint';
+
+        return `<@${row.userId}> : ${row.total}/${guild.dailyGoal} — ${status}`;
+    });
+
+    return [`Récap du jour (${progress.entryDate}) :`, ...lines].join('\n');
+}
+
+async function sendDueRecaps(client) {
+    const dueGuilds = await getDueRecapGuilds();
+
+    for (const guild of dueGuilds) {
+        try {
+            const channel = await client.channels.fetch(guild.trackedChannelId);
+
+            const progress = await getDailyProgress(guild);
+
+            if (progress.rows.length > 0) {
+                await channel.send(buildRecapMessage(guild, progress));
+            }
+
+            await markRecapSent(guild.guildId, progress.entryDate);
+        } catch (error) {
+            console.error(
+                `Échec du récap pour le serveur ${guild.guildId} :`,
+                error.message,
+            );
+        }
+    }
+}
+
+export function startScheduler(client) {
+    cron.schedule('* * * * *', () => {
+        sendDueRecaps(client).catch((error) => console.error(error));
+    });
+}


### PR DESCRIPTION
## Summary

Maintenance round: security updates, one data-integrity bug fix, /setup hardening, and the previously dormant daily-recap feature.

**No schema change — the database stays exactly as-is** (recaps use only existing columns).

### Security / dependencies
- Bump `discord.js` 14.26.4 → 14.27.0: clears all production-audit findings (high-severity undici advisories via transitive dep)
- Refresh dev tooling (`eslint` 10.9.1, `prettier` 3.9.6, `globals` 17.11.0); remove unused `eslint-plugin-jest` / `eslint-plugin-eslint-comments`; drop dead `db:generate` / `db:migrate` scripts
- Remaining `npm audit` finding is esbuild via drizzle-kit's CLI config loader only (dev-only, no server exposed)

### Bug fixes
- **Race condition**: count mutations now run in a transaction with `SELECT ... FOR UPDATE` on the entry row — concurrent `/log` / `/admin-log` can no longer lose updates or corrupt `entry_events`
- `/setup` validates IANA timezone (Luxon) and `HH:mm` reminder format before writing; invalid input gets an ephemeral French error
- Cooldown/error replies in `interactionCreate.js` translated to French (consistent with the rest of the user-facing strings)

### Feature: daily recap scheduler
- New `src/scheduler.js`, started from the ready event, ticks every minute via node-cron
- A guild gets its recap when guild-timezone `HH:mm` == `reminderTime`, `lastRecapDate != today`, and today is within `startDate + durationDays`
- Posts each active participant's day total vs `dailyGoal` to the tracked channel; failures (deleted channel, etc.) are logged and skipped
- Makes use of the previously unused `node-cron` dependency and the `trackedChannelId` / `reminderTime` / `lastRecapDate` columns

### Ops
- `restart: unless-stopped` on both compose services
- Container runs as non-root `USER node`
- Optional `GUILD_ID` env var registers slash commands instantly in one guild during dev (global registration takes up to an hour)
- New `AGENTS.md` documenting commands, architecture and gotchas

## Test plan — all verified manually

Automated checks ran against a throwaway local Postgres; live behaviour was validated end-to-end in a private Discord test server (guild `775425543243956297`) with a real recap posting at the configured time. Production DB never touched.

- [x] `npx eslint .` clean (also enforced by pre-commit hook)
- [x] `npm audit --omit=dev`: 0 vulnerabilities remaining
- [x] Schema untouched: `drizzle-kit push` reports « No changes detected » from both host and container
- [x] Race fix: script firing 20 concurrent `/log add` equivalents → final count exactly 20, no lost updates (`SELECT ... FOR UPDATE` path exercised)
- [x] `/setup` validation: invalid timezone (« Fuseau horaire invalide… ») and bad `HH:mm` (« Heure de rappel invalide… ») rejected ephemerally without writing
- [x] Re-running `/setup` upserts a single guild row; `startDate` / `lastRecapDate` deliberately preserved
- [x] Daily recap posted in the tracked channel at the configured `reminderTime`, showing per-participant `total/goal` with atteint/non atteint status; `lastRecapDate` blocked same-day duplicates (verified in DB)
- [x] French cooldown message on rapid repeat commands
- [x] Container boots as non-root (`whoami` → `node`), sequence deploy commands → schema push → Ready, 7 commands reloaded globally
- [x] Bot auto-restarts after its node process crashes (`restart: unless-stopped`)
