### PR TITLE
ci: add lint + audit workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+    push:
+        branches: [master]
+    pull_request:
+
+jobs:
+    lint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: npm
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Lint (ESLint + Prettier)
+              run: npx eslint .
+
+            - name: Security audit (production deps)
+              run: npm audit --omit=dev


### PR DESCRIPTION
Closes #2

## What

Minimal GitHub Actions workflow (`.github/workflows/ci.yml`), job name `lint`:

| Step | Command | Why |
|---|---|---|
| Setup | `actions/checkout@v4` + `setup-node@v4`, Node 22, npm cache | matches `engines: >=22.12` |
| Install | `npm ci` | clean install from lockfile |
| Lint | `npx eslint .` | Prettier runs inside ESLint as an error rule → covers style + lint in one gate |
| Audit | `npm audit --omit=dev` | fails CI on any production dependency advisory; known accepted finding (esbuild via drizzle-kit) is dev-only |

Triggers: every PR + pushes to `master`.

## After merge

Once this workflow has run green at least once on `master`, add the `lint` check as a **required status check** in the "Default branch protection" ruleset — until then it reports but doesn't block.

Optional follow-up (tracked in #2): a Postgres service job to verify `drizzle-kit push` stays non-destructive.
