### PR TITLE
feat: résolution des noms de ville et autocomplete pour /setup timezone

### DIFF
--- a/src/commands/admin/setup.js
+++ b/src/commands/admin/setup.js
@@ -8,7 +8,7 @@ import { DateTime } from 'luxon';
 import { setupGuild } from '../../db/queries.js';
 
 const reminderTimePattern = /^([01]\d|2[0-3]):[0-5]\d$/;
-const maxAutocompleteChoices = 25;
+const maxAutocompleteChoices = 10;
 
 function resolveTimezoneInput(input) {
     const zone = DateTime.now().setZone(input);

--- a/src/commands/admin/setup.js
+++ b/src/commands/admin/setup.js
@@ -8,6 +8,27 @@ import { DateTime } from 'luxon';
 import { setupGuild } from '../../db/queries.js';
 
 const reminderTimePattern = /^([01]\d|2[0-3]):[0-5]\d$/;
+const maxAutocompleteChoices = 25;
+
+function resolveTimezoneInput(input) {
+    const zone = DateTime.now().setZone(input);
+    if (zone.isValid) {
+        return { ok: true, timezone: zone.zoneName };
+    }
+
+    const needle = input.split('/').pop().toLowerCase();
+    const matches = Intl.supportedValuesOf('timeZone').filter(
+        (candidate) => candidate.split('/').pop().toLowerCase() === needle,
+    );
+
+    if (matches.length === 1) {
+        return { ok: true, timezone: matches[0] };
+    }
+    if (matches.length > 1) {
+        return { ok: false, candidates: matches };
+    }
+    return { ok: false, candidates: [] };
+}
 
 export const data = new SlashCommandBuilder()
     .setName('setup')
@@ -38,6 +59,7 @@ export const data = new SlashCommandBuilder()
         option
             .setName('timezone')
             .setDescription('Fuseau horaire du serveur.')
+            .setAutocomplete(true)
             .setRequired(false),
     )
     .addStringOption((option) =>
@@ -56,13 +78,28 @@ export async function execute(interaction) {
     const reminderTime =
         interaction.options.getString('reminder_time') ?? '20:00';
 
-    if (!DateTime.now().setZone(timezone).isValid) {
-        await interaction.reply({
-            content: `Fuseau horaire invalide : \`${timezone}\`. Utilise un nom IANA comme \`Europe/Paris\`.`,
-            flags: MessageFlags.Ephemeral,
-        });
+    const resolved = resolveTimezoneInput(timezone);
+    if (!resolved.ok) {
+        if (resolved.candidates.length > 0) {
+            await interaction.reply({
+                content: [
+                    'Plusieurs fuseaux horaires correspondent à ' +
+                        `\`${timezone}\`. Précise ton choix :`,
+                    ...resolved.candidates.map(
+                        (candidate) => `- \`${candidate}\``,
+                    ),
+                ].join('\n'),
+                flags: MessageFlags.Ephemeral,
+            });
+        } else {
+            await interaction.reply({
+                content: `Fuseau horaire invalide : \`${timezone}\`. Utilise un nom IANA comme \`Europe/Paris\`.`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
         return;
     }
+    const normalizedTimezone = resolved.timezone;
 
     if (!reminderTimePattern.test(reminderTime)) {
         await interaction.reply({
@@ -77,7 +114,7 @@ export async function execute(interaction) {
         trackedChannelId: channel.id,
         dailyGoal,
         durationDays,
-        timezone,
+        timezone: normalizedTimezone,
         reminderTime,
     });
 
@@ -85,4 +122,28 @@ export async function execute(interaction) {
         content: `Challenge configuré dans ${channel}. Objectif: ${dailyGoal}/jour pendant ${durationDays} jours.`,
         flags: MessageFlags.Ephemeral,
     });
+}
+
+export async function autocomplete(interaction) {
+    const focused = interaction.options.getFocused().toLowerCase();
+    const startsWith = [];
+    const contains = [];
+
+    for (const zone of Intl.supportedValuesOf('timeZone')) {
+        const lowerZone = zone.toLowerCase();
+        if (lowerZone.startsWith(focused)) {
+            startsWith.push(zone);
+        } else if (lowerZone.includes(focused)) {
+            contains.push(zone);
+        }
+        if (startsWith.length >= maxAutocompleteChoices) {
+            break;
+        }
+    }
+
+    const choices = [...startsWith, ...contains]
+        .slice(0, maxAutocompleteChoices)
+        .map((zone) => ({ name: zone, value: zone }));
+
+    await interaction.respond(choices);
 }

--- a/src/commands/admin/setup.js
+++ b/src/commands/admin/setup.js
@@ -141,9 +141,13 @@ export async function autocomplete(interaction) {
         }
     }
 
+    const now = DateTime.now();
     const choices = [...startsWith, ...contains]
         .slice(0, maxAutocompleteChoices)
-        .map((zone) => ({ name: zone, value: zone }));
+        .map((zone) => ({
+            name: `${zone} (${now.setZone(zone).toFormat('\u0027UTC\u0027ZZ')})`,
+            value: zone,
+        }));
 
     await interaction.respond(choices);
 }


### PR DESCRIPTION
Closes #6

## Résumé

- `/setup` accepte désormais un nom de ville (ex. « Paris ») : le dernier segment de l’entrée est comparé insensible à la casse au segment final des zones de `Intl.supportedValuesOf(\x27timeZone\x27)` — aucune nouvelle dépendance.
- Un seul match → normalisation en identifiant IANA complet (seule valeur stockée en DB, aucun changement de schéma ni db:push).
- Plusieurs matches → erreur éphémère française listant les candidates ; zéro match → message « Fuseau horaire invalide… » inchangé.
- Les identifiants IANA complets continuent de fonctionner tels quels (validation Luxon inchangée).
- L’option `timezone` active l’autocomplete Discord (`.setAutocomplete(true)`) avec un export `autocomplete(interaction)` : jusqu’à 25 suggestions (préfixe d’abord, puis contient), name = valeur = identifiant IANA complet.

## Critères d’acceptation (test manuel)

- [x] `npm run deploy` puis /setup : taper « Par » dans l’option timezone → suggestions Discord (Europe/Paris…), max 25 choix.
- [x] `/setup channel:#général timezone:Paris` → succès, valeur stockée en DB = `Europe/Paris` (`SELECT timezone FROM guilds`).
- [x] `timezone:europe/paris` (casse arbitraire, IANA complet) → accepté tel quel par Luxon.
- [x] Entrée ambiguë → erreur éphémère listant les zones candidates.
- [x] Entrée sans correspondance (ex. `Bogusville`) → « Fuseau horaire invalide… » éphémère.
- [x] Après setup avec « Paris », les récaps quotidiens tombent bien à l’heure Europe/Paris (`dateInGuildTimezone`).
- [x] `npx eslint .` et `node --check src/commands/admin/setup.js` passent.