### PR TITLE
feat: /stats user affiche tous les types d’exercices sans l’option exercise

### DIFF
--- a/src/commands/challenge/stats.js
+++ b/src/commands/challenge/stats.js
@@ -2,6 +2,7 @@ import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 import {
     EXERCISE_TYPES,
     getGlobalStats,
+    getUserAllStats,
     getUserStats,
 } from '../../db/queries.js';
 
@@ -10,12 +11,12 @@ const exerciseChoices = Object.values(EXERCISE_TYPES).map((exerciseType) => ({
     value: exerciseType,
 }));
 
-function addExerciseOption(command) {
+function addExerciseOption(command, { required = true } = {}) {
     return command.addStringOption((option) =>
         option
             .setName('exercise')
             .setDescription('Type d’exercice.')
-            .setRequired(true)
+            .setRequired(required)
             .addChoices(...exerciseChoices),
     );
 }
@@ -35,6 +36,7 @@ export const data = new SlashCommandBuilder()
             subcommand
                 .setName('user')
                 .setDescription('Stats d’un participant.'),
+            { required: false },
         ).addUserOption((option) =>
             option
                 .setName('user')
@@ -45,7 +47,7 @@ export const data = new SlashCommandBuilder()
 
 export async function execute(interaction) {
     const subcommand = interaction.options.getSubcommand();
-    const exerciseType = interaction.options.getString('exercise', true);
+    const exerciseType = interaction.options.getString('exercise');
 
     if (subcommand === 'global') {
         const result = await getGlobalStats(interaction.guildId, exerciseType);
@@ -71,6 +73,45 @@ export async function execute(interaction) {
     }
 
     const user = interaction.options.getUser('user') ?? interaction.user;
+
+    if (!exerciseType) {
+        const result = await getUserAllStats(interaction.guildId, user.id);
+
+        if (!result.ok) {
+            await interaction.reply({
+                content: `${user} n’est pas inscrit au challenge.`,
+                flags: MessageFlags.Ephemeral,
+            });
+            return;
+        }
+
+        const statsByType = new Map(
+            result.rows.map((row) => [row.exerciseType, row]),
+        );
+        let grandTotal = 0;
+
+        const lines = Object.values(EXERCISE_TYPES).map((type) => {
+            const { total, loggedDays, bestDay } = statsByType.get(type) ?? {
+                total: 0,
+                loggedDays: 0,
+                bestDay: 0,
+            };
+            grandTotal += total;
+
+            return [
+                `${type} : total ${total}`,
+                `${loggedDays} jours`,
+                `meilleur ${bestDay}`,
+            ].join(' — ');
+        });
+        lines.push(`TOTAL : ${grandTotal}`);
+
+        await interaction.reply({
+            content: [`Stats de ${user}`, ...lines].join('\n'),
+        });
+        return;
+    }
+
     const result = await getUserStats(
         interaction.guildId,
         user.id,

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -404,6 +404,39 @@ export async function getGlobalStats(guildId, exerciseType) {
     return { ok: true, stats };
 }
 
+export async function getUserAllStats(guildId, userId) {
+    const total = sql`coalesce(sum(${entries.count}), 0)`.mapWith(Number);
+    const loggedDays = sql`count(${entries.id})`.mapWith(Number);
+    const bestDay = sql`coalesce(max(${entries.count}), 0)`.mapWith(Number);
+
+    const rows = await db
+        .select({
+            exerciseType: entries.exerciseType,
+            total,
+            loggedDays,
+            bestDay,
+        })
+        .from(participants)
+        .leftJoin(entries, eq(entries.participantId, participants.id))
+        .where(
+            and(
+                eq(participants.guildId, guildId),
+                eq(participants.userId, userId),
+                eq(participants.active, true),
+            ),
+        )
+        .groupBy(entries.exerciseType);
+
+    if (rows.length === 0) {
+        return { ok: false, reason: 'not_joined' };
+    }
+
+    return {
+        ok: true,
+        rows: rows.filter((row) => row.exerciseType !== null),
+    };
+}
+
 export async function getUserStats(guildId, userId, exerciseType) {
     if (!isExerciseType(exerciseType)) {
         return { ok: false, reason: 'invalid_exercise_type' };


### PR DESCRIPTION
Closes #5

## Résumé

- `src/commands/challenge/stats.js` : l’option `exercise` devient optionnelle sur la sous-commande `user` uniquement (`global` et `leaderboard` inchangés). Sans `exercise`, la réponse liste une ligne par type de `EXERCISE_TYPES` (`PUSHUP : total X — Y jours — meilleur Z`) plus une ligne `TOTAL : X`. Avec `exercise`, comportement inchangé.
- `src/db/queries.js` : nouvelle fonction exportée `getUserAllStats(guildId, userId)` — une seule requête avec `GROUP BY exercise_type` sur `entries` jointes au participant actif (join sur `participants`, filtre guild/user/active), retournant par type : total, jours loggés, meilleur jour. Convention `{ ok, reason }` respectée avec `reason: not_joined` si non inscrit. Aucun changement de schéma, lecture seule.

## Comment tester manuellement

1. `npm run deploy` (ou via le conteneur) pour enregistrer la commande modifiée.
2. Dans un serveur configuré (`/setup`) et après `/join` + quelques `/log` :
   - `/stats user` sans option → une réponse avec 4 lignes (PUSHUP, SQUAT, CRUNCH, RUNNING) au format `TYPE : total X — Y jours — meilleur Z` et une ligne `TOTAL`.
   - `/stats user exercise:PUSHUP` → affichage détaillé identique à avant (Total / Jours loggés / Meilleur jour).
   - `/stats user @quelqu_un_non_inscrit` → message éphémère « n’est pas inscrit au challenge. »
   - Vérifier que `/stats global` exige toujours `exercise`.

## Vérifications

- `npx eslint .` : OK (prettier inclus)
- `node --check src/db/queries.js src/commands/challenge/stats.js` : OK