### PR TITLE
feat: automatic daily Postgres backups (db-backup sidecar)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,8 @@ POSTGRES_USER=pushup
 POSTGRES_PASSWORD=change_me
 POSTGRES_DB=pushup_challenge
 DATABASE_URL=postgresql://pushup:change_me@db:5432/pushup_challenge
+
+# Optional: db-backup service (defaults set in compose.yml).
+# Seconds between dumps (default 86400 = daily) and retention in days (default 7).
+# BACKUP_INTERVAL_SECONDS=86400
+# BACKUP_RETENTION_DAYS=7

--- a/README.md
+++ b/README.md
@@ -5,3 +5,50 @@ docker compose build bot
 docker compose run --rm bot node src/deploy-commands.js
 docker compose up -d
 ```
+
+## Sauvegardes
+
+Le service `db-backup` (démarré avec `docker compose up -d`) effectue un dump
+compressé (`pg_dump -Fc`) de la base à intervalle régulier. Opération strictement
+en lecture seule : aucune écriture, aucune modification de schéma.
+
+- Emplacement des dumps : volume nommé `backups_data`, monté sur `/backups`
+  dans le conteneur `db-backup` (jamais dans `postgres_data`). Fichiers
+  `pushup_challenge_AAAAMMJJ_HHMMSS.dump`.
+- Réglages optionnels via `.env` :
+    - `BACKUP_INTERVAL_SECONDS` : secondes entre deux dumps (défaut `86400`,
+      soit quotidien).
+    - `BACKUP_RETENTION_DAYS` : conservation en jours (défaut `7`, les dumps
+      plus anciens sont purgés automatiquement).
+
+```bash
+# Lister les dumps
+docker compose exec db-backup ls -lh /backups
+
+# Copier un dump hors du volume (à faire régulièrement : offsite)
+docker compose cp db-backup:/backups/<fichier>.dump ./<fichier>.dump
+```
+
+### Restauration
+
+`--clean --if-exists` supprime les objets existants avant de les recréer :
+le contenu actuel de la base est remplacé par celui du dump.
+
+```bash
+docker compose stop bot  # éviter toute écriture pendant la restauration
+docker compose exec db-backup sh -c 'PGPASSWORD="$POSTGRES_PASSWORD" \
+    pg_restore --clean --if-exists --no-owner \
+    -h db -U "$POSTGRES_USER" -d "$POSTGRES_DB" /backups/<fichier>.dump'
+docker compose start bot
+```
+
+Depuis une copie locale du fichier :
+
+```bash
+docker compose exec -T db pg_restore --clean --if-exists --no-owner \
+    -U pushup -d pushup_challenge < ./<fichier>.dump
+```
+
+**Attention :** ne jamais lancer `docker compose down -v` — cela supprimerait
+le volume `postgres_data` **et** le volume `backups_data` (données et
+sauvegardes définitivement perdues).

--- a/README.md
+++ b/README.md
@@ -6,49 +6,52 @@ docker compose run --rm bot node src/deploy-commands.js
 docker compose up -d
 ```
 
-## Sauvegardes
+## Backups
 
-Le service `db-backup` (démarré avec `docker compose up -d`) effectue un dump
-compressé (`pg_dump -Fc`) de la base à intervalle régulier. Opération strictement
-en lecture seule : aucune écriture, aucune modification de schéma.
+The `db-backup` service (started with `docker compose up -d`) takes a
+compressed dump (`pg_dump -Fc`) of the database at a regular interval.
+Strictly read-only: no writes, no schema changes.
 
-- Emplacement des dumps : volume nommé `backups_data`, monté sur `/backups`
-  dans le conteneur `db-backup` (jamais dans `postgres_data`). Fichiers
-  `pushup_challenge_AAAAMMJJ_HHMMSS.dump`.
-- Réglages optionnels via `.env` :
-    - `BACKUP_INTERVAL_SECONDS` : secondes entre deux dumps (défaut `86400`,
-      soit quotidien).
-    - `BACKUP_RETENTION_DAYS` : conservation en jours (défaut `7`, les dumps
-      plus anciens sont purgés automatiquement).
+- Dump location: named volume `backups_data`, mounted at `/backups` in the
+  `db-backup` container (never inside `postgres_data`). Files are named
+  `pushup_challenge_YYYYMMDD_HHMMSS.dump`.
+- Optional settings via `.env`:
+    - `BACKUP_INTERVAL_SECONDS`: seconds between two dumps (default `86400`,
+      i.e. daily). Note that a dump is also taken on every container start.
+    - `BACKUP_RETENTION_DAYS`: days to keep dumps (default `7`; older dumps
+      are pruned automatically).
+
+Every archive is verified with `pg_restore -l` right after the dump; a corrupt
+or truncated file is deleted instead of being kept as a false backup.
 
 ```bash
-# Lister les dumps
+# List dumps
 docker compose exec db-backup ls -lh /backups
 
-# Copier un dump hors du volume (à faire régulièrement : offsite)
-docker compose cp db-backup:/backups/<fichier>.dump ./<fichier>.dump
+# Copy a dump off the host regularly (offsite — cloud sync tracked in #10)
+docker compose cp db-backup:/backups/<file>.dump ./<file>.dump
 ```
 
-### Restauration
+### Restore
 
-`--clean --if-exists` supprime les objets existants avant de les recréer :
-le contenu actuel de la base est remplacé par celui du dump.
+`--clean --if-exists` drops existing objects before recreating them: the
+current database content is replaced by the dump content.
 
 ```bash
-docker compose stop bot  # éviter toute écriture pendant la restauration
+docker compose stop bot  # avoid writes during the restore
 docker compose exec db-backup sh -c 'PGPASSWORD="$POSTGRES_PASSWORD" \
     pg_restore --clean --if-exists --no-owner \
-    -h db -U "$POSTGRES_USER" -d "$POSTGRES_DB" /backups/<fichier>.dump'
+    -h db -U "$POSTGRES_USER" -d "$POSTGRES_DB" /backups/<file>.dump'
 docker compose start bot
 ```
 
-Depuis une copie locale du fichier :
+From a local copy of the file:
 
 ```bash
 docker compose exec -T db pg_restore --clean --if-exists --no-owner \
-    -U pushup -d pushup_challenge < ./<fichier>.dump
+    -U pushup -d pushup_challenge < ./<file>.dump
 ```
 
-**Attention :** ne jamais lancer `docker compose down -v` — cela supprimerait
-le volume `postgres_data` **et** le volume `backups_data` (données et
-sauvegardes définitivement perdues).
+**Warning:** never run `docker compose down -v` — it would delete the
+`postgres_data` volume **and** the `backups_data` volume (data and backups
+permanently lost).

--- a/compose.yml
+++ b/compose.yml
@@ -50,7 +50,8 @@ services:
                     done
                     stamp="$$(date +%Y%m%d_%H%M%S)"
                     file="/backups/$${POSTGRES_DB}_$${stamp}.dump"
-                    if pg_dump -h db -U "$${POSTGRES_USER}" -Fc -f "$$file" "$${POSTGRES_DB}"; then
+                    if pg_dump -h db -U "$${POSTGRES_USER}" -Fc -f "$$file" "$${POSTGRES_DB}" \
+                        && pg_restore -l "$$file" >/dev/null 2>&1; then
                         echo "[db-backup] dump ok: $$file ($$(du -h "$$file" | cut -f1))"
                     else
                         rm -f "$$file"

--- a/compose.yml
+++ b/compose.yml
@@ -22,5 +22,45 @@ services:
         volumes:
             - postgres_data:/var/lib/postgresql/data
 
+    db-backup:
+        image: postgres:17-alpine
+        restart: unless-stopped
+        depends_on:
+            - db
+        environment:
+            POSTGRES_USER: ${POSTGRES_USER}
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+            POSTGRES_DB: ${POSTGRES_DB}
+            BACKUP_INTERVAL_SECONDS: ${BACKUP_INTERVAL_SECONDS:-86400}
+            BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-7}
+        volumes:
+            - backups_data:/backups
+        entrypoint:
+            - /bin/sh
+            - -ec
+            - |
+                export PGPASSWORD="$${POSTGRES_PASSWORD}"
+                interval="$${BACKUP_INTERVAL_SECONDS:-86400}"
+                retention_days="$${BACKUP_RETENTION_DAYS:-7}"
+                echo "[db-backup] interval=$${interval}s retention_days=$${retention_days}"
+                while :; do
+                    until pg_isready -h db -U "$${POSTGRES_USER}" -q; do
+                        echo '[db-backup] waiting for db...'
+                        sleep 10
+                    done
+                    stamp="$$(date +%Y%m%d_%H%M%S)"
+                    file="/backups/$${POSTGRES_DB}_$${stamp}.dump"
+                    if pg_dump -h db -U "$${POSTGRES_USER}" -Fc -f "$$file" "$${POSTGRES_DB}"; then
+                        echo "[db-backup] dump ok: $$file ($$(du -h "$$file" | cut -f1))"
+                    else
+                        rm -f "$$file"
+                        echo '[db-backup] dump failed' >&2
+                    fi
+                    find /backups -name '*.dump' -type f \
+                        -mmin +"$$((retention_days * 1440))" -delete
+                    sleep "$$interval"
+                done
+
 volumes:
     postgres_data:
+    backups_data:


### PR DESCRIPTION
Closes #4

## Résumé

- Nouveau service `db-backup` dans `compose.yml`, image officielle `postgres:17-alpine` (aucune dépendance tierce). Boucle `sh` autonome :
    - attend la readiness de `db` (`pg_isready`) ;
    - dump compressé `pg_dump -Fc` → `/backups/<POSTGRES_DB>_<timestamp>.dump` ;
    - purge des dumps de plus de `BACKUP_RETENTION_DAYS` jours (défaut 7) via `find -mmin`.
- Volume dédié `backups_data` monté sur `/backups` — jamais dans `postgres_data`. Réutilise `POSTGRES_USER`/`POSTGRES_DB`/`POSTGRES_PASSWORD` existants.
- Intervalle configurable : `BACKUP_INTERVAL_SECONDS` (défaut 86400 s = quotidien) ; réglages documentés en commentaire dans `.env.example`.
- Lecture seule vis-à-vis de la base : uniquement `pg_isready`/`pg_dump`, aucune écriture, aucun changement de schéma.
- README : nouvelle section « Sauvegardes » — emplacement des dumps, copie offsite, procédure de restauration (`pg_restore --clean --if-exists --no-owner`) et avertissement explicite contre `docker compose down -v`.

## Vérifications

- [x] `docker compose config` valide (interpolation et défauts corrects).
- [x] Test réel avec `docker compose up -d db db-backup` uniquement (jamais `bot`) :
    - log `[db-backup] dump ok: /backups/pushup_challenge_20260825_211748.dump` après attente de readiness ;
    - fichier présent dans le volume, non vide (871 o sur une base fraîche) ;
    - `pg_restore -l` confirme le format CUSTOM compressé (gzip), bonne base ;
    - purge : `find -mmin` supporté par busybox (testé positivement), conteneur toujours up après son exécution ;
    - `docker compose stop db-backup` effectué, environnement de test nettoyé (`down` sans `-v`).
- [x] Aucun changement JS ; `npx eslint .` passe.

Note test : le port hôte 5432 étant occupé par une autre stack locale, un override temporaire (supprimé depuis) publiait `db` sur 15432 — sans impact, le backup passe par le réseau interne compose.
