### PR TITLE
feat: offsite backup sync via rclone sidecar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,9 @@ DATABASE_URL=postgresql://pushup:change_me@db:5432/pushup_challenge
 # Seconds between dumps (default 86400 = daily) and retention in days (default 7).
 # BACKUP_INTERVAL_SECONDS=86400
 # BACKUP_RETENTION_DAYS=7
+
+# Optional: db-offsite service (defaults set in compose.yml).
+# Seconds between offsite syncs (default 86400 = daily) and retention in days
+# (default 30) for copies stored on the rclone remote.
+# OFFSITE_INTERVAL_SECONDS=86400
+# OFFSITE_RETENTION_DAYS=30

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .env
 config.json
 node_modules
+rclone.conf

--- a/README.md
+++ b/README.md
@@ -100,8 +100,37 @@ or truncated file is deleted instead of being kept as a false backup.
 # List dumps
 docker compose exec db-backup ls -lh /backups
 
-# Copy a dump off the host regularly (offsite — cloud sync tracked in #10)
+# Copy a dump off the host manually (see Offsite sync below for automatic sync)
 docker compose cp db-backup:/backups/<file>.dump ./<file>.dump
+```
+
+### Offsite sync
+
+The `db-offsite` service pushes recent dumps offsite once a day with
+[rclone](https://rclone.org/): only files newer than 48h are uploaded, and
+copies older than `OFFSITE_RETENTION_DAYS` (default 30) are pruned on the
+remote (`remote:pushup-backups`).
+
+It expects a `rclone.conf` file at the repository root defining a remote named
+`remote` (any rclone-supported provider works). Create it once on any machine
+with rclone installed:
+
+```bash
+rclone config   # pick your provider, name the remote "remote"
+cp ~/.config/rclone/rclone.conf ./rclone.conf
+```
+
+The file holds provider credentials: it is already git-ignored — never commit
+it. Optional settings via `.env`:
+
+- `OFFSITE_INTERVAL_SECONDS`: seconds between two syncs (default `86400`,
+  i.e. daily).
+- `OFFSITE_RETENTION_DAYS`: days to keep dumps on the remote (default `30`;
+  older remote copies are pruned automatically).
+
+```bash
+# Verify what was pushed
+docker compose exec db-offsite rclone lsl remote:pushup-backups
 ```
 
 ### Restore

--- a/compose.yml
+++ b/compose.yml
@@ -62,6 +62,28 @@ services:
                     sleep "$$interval"
                 done
 
+    db-offsite:
+        image: rclone/rclone
+        restart: unless-stopped
+        depends_on:
+            - db-backup
+        environment:
+            OFFSITE_INTERVAL_SECONDS: ${OFFSITE_INTERVAL_SECONDS:-86400}
+            OFFSITE_RETENTION_DAYS: ${OFFSITE_RETENTION_DAYS:-30}
+        volumes:
+            - backups_data:/backups:ro
+            - ./rclone.conf:/config/rclone/rclone.conf:ro
+        entrypoint:
+            - /bin/sh
+            - -ec
+            - |
+                echo '[db-offsite] pushing dumps offsite'
+                while :; do
+                    sleep "$${OFFSITE_INTERVAL_SECONDS:-86400}"
+                    rclone copy /backups remote:pushup-backups --max-age 48h
+                    rclone delete remote:pushup-backups --min-age "$${OFFSITE_RETENTION_DAYS:-30}d"
+                done
+
 volumes:
     postgres_data:
     backups_data:


### PR DESCRIPTION
## Summary
- Add a `db-offsite` sidecar service (`rclone/rclone`) that pushes recent pg_dump dumps from the `backups_data` volume to `remote:pushup-backups` once a day, uploading only files newer than 48h (`--max-age`) and pruning remote copies older than `OFFSITE_RETENTION_DAYS` (default 30) with `--min-age`.
- `backups_data` is mounted read-only and the loop sleeps first, so the service never writes locally and no sync fires before dumps exist.
- `rclone.conf` (provider credentials, mounted read-only at `/config/rclone/rclone.conf:ro`) is added to `.gitignore` — never committed.
- README documents creating the remote with `rclone config`; `.env.example` documents `OFFSITE_INTERVAL_SECONDS` (default 86400) and `OFFSITE_RETENTION_DAYS` (default 30).
- No change to the existing db-backup dump loop.

Closes #10