### PR TITLE
feat: shared loadCommands() loader for slash-command discovery

### DIFF
--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -1,9 +1,6 @@
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
 import { REST, Routes } from 'discord.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { loadCommands } from './loaders/commands.js';
 
 const token = process.env.DISCORD_TOKEN;
 const clientId = process.env.APP_ID;
@@ -11,27 +8,8 @@ const clientId = process.env.APP_ID;
 // globally, which can take up to an hour to propagate.
 const guildId = process.env.GUILD_ID;
 
-const commands = [];
-const foldersPath = path.join(__dirname, 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
-
-for (const folder of commandFolders) {
-    const commandsPath = path.join(foldersPath, folder);
-    const commandFiles = fs
-        .readdirSync(commandsPath)
-        .filter((file) => file.endsWith('.js'));
-    for (const file of commandFiles) {
-        const filePath = path.join(commandsPath, file);
-        const command = await import(pathToFileURL(filePath).href);
-        if ('data' in command && 'execute' in command) {
-            commands.push(command.data.toJSON());
-        } else {
-            console.log(
-                `[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`,
-            );
-        }
-    }
-}
+const commandModules = await loadCommands();
+const commands = commandModules.map((command) => command.data.toJSON());
 
 const rest = new REST().setToken(token);
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ import {
     // MessageFlags,
 } from 'discord.js';
 
+import { loadCommands } from './loaders/commands.js';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Create a new client instance
@@ -17,25 +19,9 @@ const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection();
 client.cooldowns = new Collection();
 
-const foldersPath = path.join(__dirname, 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
-
-for (const folder of commandFolders) {
-    const commandsPath = path.join(foldersPath, folder);
-    const commandFiles = fs
-        .readdirSync(commandsPath)
-        .filter((file) => file.endsWith('.js'));
-    for (const file of commandFiles) {
-        const filePath = path.join(commandsPath, file);
-        const command = await import(pathToFileURL(filePath).href);
-        if ('data' in command && 'execute' in command) {
-            client.commands.set(command.data.name, command);
-        } else {
-            console.log(
-                `[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`,
-            );
-        }
-    }
+const commands = await loadCommands();
+for (const command of commands) {
+    client.commands.set(command.data.name, command);
 }
 
 // --- Events ---

--- a/src/loaders/commands.js
+++ b/src/loaders/commands.js
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export async function loadCommands() {
+    const loadersDir = path.dirname(fileURLToPath(import.meta.url));
+    const srcDir = path.dirname(loadersDir);
+    const foldersPath = path.join(srcDir, 'commands');
+    const commandFolders = fs.readdirSync(foldersPath);
+
+    const commands = [];
+
+    for (const folder of commandFolders) {
+        const commandsPath = path.join(foldersPath, folder);
+        const commandFiles = fs
+            .readdirSync(commandsPath)
+            .filter((file) => file.endsWith('.js'));
+        for (const file of commandFiles) {
+            const filePath = path.join(commandsPath, file);
+            const command = await import(pathToFileURL(filePath).href);
+            if ('data' in command && 'execute' in command) {
+                commands.push(command);
+            } else {
+                console.log(
+                    `[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`,
+                );
+            }
+        }
+    }
+
+    return commands;
+}


### PR DESCRIPTION
## Summary

Extract the slash-command discovery logic duplicated between `src/index.js` and `src/deploy-commands.js` into a single shared loader, as proposed in #17.

- New **`src/loaders/commands.js`**: exports `async function loadCommands()` that walks `src/commands/<group>/*.js`, dynamically imports each file, validates the required `data` / `execute` exports, and returns the validated command modules.
- **`src/index.js`** now fills `client.commands` from `loadCommands()` instead of its inline discovery loop; event loading is untouched.
- **`src/deploy-commands.js`** maps `loadCommands()` to `.data.toJSON()` for the REST payload; unused `node:fs` / `node:path` / `node:url` imports removed.

Behavior is unchanged for both startup and deployment:

- Same directory walk and import order → same command order.
- Same validation rule (`'data' in command && 'execute' in command`) and the exact same `[WARNING] The command at ${filePath} ...` log line for files missing required exports.

## Verification

- `npx eslint .` — green (0 errors).
- `node --check` passes on all three touched files.
- Runtime smoke test of the loader: discovers all 7 commands (`admin-log, setup, join, leaderboard, leave, log, stats`) each exporting `data.name` + an `execute` function.

Closes #17
