### PR TITLE
feat: résolution de timezone tolérante aux typos

### DIFF
--- a/src/commands/admin/setup.js
+++ b/src/commands/admin/setup.js
@@ -7,6 +7,9 @@ import {
 import { DateTime } from 'luxon';
 import { getGuild, isGuildConfigured, setupGuild } from '../../db/queries.js';
 import {
+    candidateScore,
+    maxAutocompleteFuzzyDistance,
+    minFuzzyInputLength,
     reminderTimePattern,
     resolveTimezoneInput,
 } from '../../utils/timezones.js';
@@ -98,6 +101,16 @@ export async function execute(interaction) {
                 ].join('\n'),
                 flags: MessageFlags.Ephemeral,
             });
+        } else if (resolved.suggestions?.length > 0) {
+            await interaction.reply({
+                content: [
+                    `Je ne connais pas \`${timezone}\`. Voulais-tu dire… ?`,
+                    ...resolved.suggestions.map(
+                        (candidate) => `- \`${candidate}\``,
+                    ),
+                ].join('\n'),
+                flags: MessageFlags.Ephemeral,
+            });
         } else {
             await interaction.reply({
                 content: `Fuseau horaire invalide : \`${timezone}\`. Utilise un nom IANA comme \`Europe/Paris\`.`,
@@ -151,6 +164,7 @@ export async function autocomplete(interaction) {
     const focused = interaction.options.getFocused().toLowerCase();
     const startsWith = [];
     const contains = [];
+    const fuzzy = [];
 
     for (const zone of Intl.supportedValuesOf('timeZone')) {
         const lowerZone = zone.toLowerCase();
@@ -158,14 +172,37 @@ export async function autocomplete(interaction) {
             startsWith.push(zone);
         } else if (lowerZone.includes(focused)) {
             contains.push(zone);
+        } else if (focused.trim().length >= minFuzzyInputLength) {
+            const score = candidateScore(zone, focused);
+            if (score <= maxAutocompleteFuzzyDistance) {
+                fuzzy.push({ zone, score });
+            }
         }
         if (startsWith.length >= maxAutocompleteChoices) {
             break;
         }
     }
 
+    fuzzy.sort(
+        (first, second) =>
+            first.score - second.score || first.zone.localeCompare(second.zone),
+    );
+
     const now = DateTime.now();
     const choices = [...startsWith, ...contains]
+        .concat(
+            fuzzy
+                .slice(
+                    0,
+                    Math.max(
+                        0,
+                        maxAutocompleteChoices -
+                            startsWith.length -
+                            contains.length,
+                    ),
+                )
+                .map((entry) => entry.zone),
+        )
         .slice(0, maxAutocompleteChoices)
         .map((zone) => ({
             name: `${zone} (${now.setZone(zone).toFormat('\u0027UTC\u0027ZZ')})`,

--- a/src/utils/levenshtein.js
+++ b/src/utils/levenshtein.js
@@ -1,0 +1,32 @@
+// Distance de Levenshtein entre deux chaînes : nombre minimal
+// d'insertions, de suppressions et de substitutions de caractères
+// pour transformer `a` en `b`. Implémentation sans dépendance,
+// mémoire réduite à deux lignes de matrice.
+export function levenshtein(a, b) {
+    if (a === b) {
+        return 0;
+    }
+    if (a.length === 0) {
+        return b.length;
+    }
+    if (b.length === 0) {
+        return a.length;
+    }
+
+    let previousRow = Array.from({ length: b.length + 1 }, (_, i) => i);
+
+    for (let i = 1; i <= a.length; i += 1) {
+        const currentRow = [i];
+        for (let j = 1; j <= b.length; j += 1) {
+            const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+            currentRow[j] = Math.min(
+                previousRow[j] + 1,
+                currentRow[j - 1] + 1,
+                previousRow[j - 1] + substitutionCost,
+            );
+        }
+        previousRow = currentRow;
+    }
+
+    return previousRow[b.length];
+}

--- a/src/utils/timezones.js
+++ b/src/utils/timezones.js
@@ -1,6 +1,32 @@
 import { DateTime } from 'luxon';
+import { levenshtein } from './levenshtein.js';
 
 export const reminderTimePattern = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export const minFuzzyInputLength = 3;
+const maxFuzzyDistance = 4;
+export const maxAutocompleteFuzzyDistance = 3;
+const directResolutionGap = 2;
+
+export function candidateScore(zone, needle) {
+    const lowerZone = zone.toLowerCase();
+    return Math.min(
+        levenshtein(needle, lowerZone),
+        levenshtein(needle, lowerZone.split('/').pop()),
+    );
+}
+
+function rankZones(input, supportedZones) {
+    const needle = input.trim().toLowerCase();
+    const scored = supportedZones
+        .map((zone) => ({ zone, score: candidateScore(zone, needle) }))
+        .sort(
+            (first, second) =>
+                first.score - second.score ||
+                first.zone.localeCompare(second.zone),
+        );
+    return { needle, scored };
+}
 
 export function resolveTimezoneInput(
     input,
@@ -22,5 +48,23 @@ export function resolveTimezoneInput(
     if (matches.length > 1) {
         return { ok: false, candidates: matches };
     }
-    return { ok: false, candidates: [] };
+
+    if (input.trim().length < minFuzzyInputLength) {
+        return { ok: false, candidates: [], suggestions: [] };
+    }
+
+    const { scored } = rankZones(input, supportedZones);
+    const [best, second] = scored;
+    if (
+        best.score <= maxFuzzyDistance &&
+        best.score + directResolutionGap <= second.score
+    ) {
+        return { ok: true, timezone: best.zone };
+    }
+
+    const suggestions = scored
+        .slice(0, 3)
+        .filter((candidate) => candidate.score <= maxFuzzyDistance)
+        .map((candidate) => candidate.zone);
+    return { ok: false, candidates: [], suggestions };
 }

--- a/test/timezones.test.js
+++ b/test/timezones.test.js
@@ -87,10 +87,12 @@ describe('resolveTimezoneInput', () => {
             assert.deepEqual(resolveTimezoneInput('Atlantis/City'), {
                 ok: false,
                 candidates: [],
+                suggestions: [],
             });
             assert.deepEqual(resolveTimezoneInput('Nowhereville'), {
                 ok: false,
                 candidates: [],
+                suggestions: [],
             });
         });
 
@@ -98,15 +100,23 @@ describe('resolveTimezoneInput', () => {
             assert.deepEqual(resolveTimezoneInput(''), {
                 ok: false,
                 candidates: [],
+                suggestions: [],
             });
-            assert.deepEqual(resolveTimezoneInput('Paris/Foo'), {
+            // Below the fuzzy threshold: no silent resolution, no suggestions.
+            assert.deepEqual(resolveTimezoneInput('Pa'), {
                 ok: false,
                 candidates: [],
+                suggestions: [],
             });
-            assert.deepEqual(resolveTimezoneInput('Paris/'), {
-                ok: false,
-                candidates: [],
-            });
+        });
+
+        it('suggests near matches for a typo instead of resolving silently', () => {
+            // #22: a fuzzy input close to one zone returns it as a suggestion,
+            // never a silent resolution.
+            const result = resolveTimezoneInput('Paris/Foo');
+            assert.equal(result.ok, false);
+            assert.deepEqual(result.candidates, []);
+            assert.ok(result.suggestions.includes('Europe/Paris'));
         });
     });
 


### PR DESCRIPTION
Closes #22

## Résumé

Rend `/setup` tolérant aux typos sur le champ `timezone` via distance de Levenshtein, sans nouvelle dépendance.

## Changements

- **`src/utils/levenshtein.js`** (nouveau) : distance de Levenshtein pure, sans dépendance, mémoire en deux lignes.
- **`src/commands/admin/setup.js`** :
  - `resolveTimezoneInput()` : après échec du match exact suffixe/ville (comportement inchangé), les zones IANA sont classées par distance minimale sur nom complet **et** segment ville. Si le meilleur candidat devance le second d'au moins 2 points → résolution directe. Sinon, si distance ≤ 4 → top 3 suggéré en message éphémère (« Je ne connais pas \`...\`. Voulais-tu dire… ? »).
  - Garde-fous : input < 3 caractères ou trop éloigné de toute zone (`xyzzy!!!`) → erreur classique, jamais de suggestion hasardeuse ; les entrées ambiguës ne sont **jamais** résolues silencieusement.
  - Autocomplete : logique prefix/contains conservée ; complétion fuzzy (distance ≤ 3) uniquement quand les résultats exacts sont insuffisants.

## Vérification

- `npx eslint .` ✅ vert · `node --check` sur les 2 fichiers ✅
- Tests manuels (`node -e`, fonction exportée temporairement) :

| Input | Résultat |
|---|---|
| `Par1s` | ✅ résolu → `Europe/Paris` |
| `Tokio` | ✅ résolu → `Asia/Tokyo` |
| `Europe/Pari` / `New York` / `Madrid` | ✅ résolus |
| `Londres` | 💡 suggestions : `Europe/London`, … (pas de résolution silencieuse) |
| `san` / `par` (ambigu) | 💡 top 3 suggéré |
| `Madrid vs Barcelona derby` / `xyzzy!!!` | ❌ erreur invalide classique |
| `Europe/Paris` | ✅ chemin direct inchangé |

- Levenshtein validé sur cas canoniques : `kitten/sitting=3`, `flaw/lawn=2`, `Par1s/paris=2`.