### PR TITLE
feat(db): per-exercise daily goals storage (additive table + backfill) (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ Inside the container, `src/start_bot.sh` re-registers slash commands and applies
 the schema (`drizzle-kit push`) before starting the bot. Copy `.env.example` to
 `.env` and fill in your Discord credentials and database settings first.
 
+### Per-exercise goals migration (#18)
+
+1. `npm run db:push -- --force` creates the new `guild_exercise_goals` table —
+   a purely additive `CREATE TABLE`, no existing data is touched. The `--force`
+   flag skips drizzle-kit's interactive confirmation so the step runs
+   unattended (verified: a bare `CREATE TABLE` applies cleanly on an existing
+   database).
+2. Backfill existing guilds:
+
+    ```bash
+    docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+        < scripts/backfill-exercise-goals.sql
+    ```
+
+3. Verify: every configured guild must have exactly 4 rows (one per exercise
+   type), each carrying the guild's previous `dailyGoal`. The script is
+   idempotent and can be re-run safely.
+
 ## Local development
 
 Requirements: Node >= 22.12, Docker.

--- a/scripts/backfill-exercise-goals.sql
+++ b/scripts/backfill-exercise-goals.sql
@@ -1,0 +1,21 @@
+-- Per-exercise goals backfill (#18).
+--
+-- Copies each guild's legacy single daily goal (guilds.daily_goal) into one
+-- guild_exercise_goals row per exercise type, so every guild keeps its
+-- previous goal on all four exercises.
+--
+-- Idempotent: INSERT ... SELECT ... ON CONFLICT (guild_id, exercise_type)
+-- DO NOTHING. ON CONFLICT DO NOTHING makes the script safe to re-run: rows
+-- that already exist (e.g. goals customized after an earlier run) are left
+-- untouched instead of duplicated or overwritten.
+
+INSERT INTO guild_exercise_goals (guild_id, exercise_type, daily_goal)
+SELECT
+    g.guild_id,
+    t.exercise_type::exercise_type,
+    g.daily_goal
+FROM guilds g
+CROSS JOIN (
+    VALUES ('PUSHUP'), ('SQUAT'), ('CRUNCH'), ('RUNNING')
+) AS t(exercise_type)
+ON CONFLICT (guild_id, exercise_type) DO NOTHING;

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -8,7 +8,10 @@ import {
     serial,
     unique,
     boolean,
+    check,
+    primaryKey,
 } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 
 export const EXERCISE_TYPES = {
     PUSHUP: 'PUSHUP',
@@ -27,11 +30,34 @@ export const guilds = pgTable('guilds', {
     trackedChannelId: text('tracked_channel_id'),
     startDate: date('start_date'),
     durationDays: integer('duration_days').notNull().default(30),
+    /**
+     * @deprecated Since issue #18. Replaced by the per-exercise goals in
+     * `guildExerciseGoals`; stop reading/writing this column when UX v2
+     * (#19) ships. Drop deferred.
+     */
     dailyGoal: integer('daily_goal').notNull().default(100),
     timezone: text('timezone').notNull().default('Europe/Paris'),
     reminderTime: text('reminder_time').notNull().default('20:00'),
     lastRecapDate: date('last_recap_date'),
 });
+
+export const guildExerciseGoals = pgTable(
+    'guild_exercise_goals',
+    {
+        guildId: text('guild_id')
+            .notNull()
+            .references(() => guilds.guildId, { onDelete: 'cascade' }),
+        exerciseType: exerciseTypeEnum('exercise_type').notNull(),
+        dailyGoal: integer('daily_goal').notNull(),
+    },
+    (table) => [
+        primaryKey({ columns: [table.guildId, table.exerciseType] }),
+        check(
+            'guild_exercise_goals_daily_goal_check',
+            sql`${table.dailyGoal} > 0`,
+        ),
+    ],
+);
 
 export const participants = pgTable(
     'participants',


### PR DESCRIPTION
Closes #18

## Summary

Purely additive storage layer for per-exercise daily goals — prerequisite for
the configuration UX v2 (#19). **No behaviour change**: no command, query or
mutation is touched in this PR.

**Stacked on #24** (`refactor/split-db-queries-by-concern`) — merge order:
**#24 first**, then this one. Base branch is intentionally NOT master.

## What's in it

- **`src/db/schema.js`**
    - New `guild_exercise_goals` table: composite PK `(guild_id,
      exercise_type)`, FK to `guilds(guild_id)` `ON DELETE CASCADE`,
      `daily_goal integer NOT NULL CHECK (daily_goal > 0)`, reusing the
      existing `exercise_type` PG enum (values imported from
      `EXERCISE_TYPES`, single source of truth).
    - `guilds.dailyGoal` stays physically in place, now marked `@deprecated`
      with a pointer to this table; stop reading/writing it when UX v2 (#19)
      lands. Dropping is deferred to a dedicated future pass.
- **`scripts/backfill-exercise-goals.sql`** (new): idempotent
  `INSERT … SELECT … CROSS JOIN (VALUES ('PUSHUP'),('SQUAT'),('CRUNCH'),
  ('RUNNING')) … ON CONFLICT DO NOTHING`, copying each guild's legacy
  `daily_goal` into one row per exercise type. Note: the enum cast
  (`t.exercise_type::exercise_type`) is required — a bare `VALUES` list is
  typed `text`.
- **`README.md`**: new "Per-exercise goals migration (#18)" subsection under
  Deployment documenting the exact order of execution.

## Migration procedure (push-based workflow, no migrations folder)

1. **Backup first** — existing `db-backup` service covers this.
2. `npm run db:push -- --force` → creates the table. Purely additive
   `CREATE TABLE`; nothing else changes.
3. Backfill:
   ```bash
   docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
       < scripts/backfill-exercise-goals.sql
   ```
4. Verify every configured guild has exactly 4 rows matching its old
   `dailyGoal`.

## Validation performed

No live DATABASE_URL was available in the working environment, so beyond
static checks (`node --check`, `npx eslint .` green, schema introspected via
`getTableConfig`: columns/PK/CHECK/FK/enum all as specced) the full flow was
exercised against an **ephemeral embedded Postgres 18**:

- seeded legacy state (2 guilds, goals 100/150)
- `drizzle-kit push --force` applied **non-interactively**, producing exactly
  the expected table (PK, CHECK constraint, FK cascade verified in catalog);
  `guilds` data untouched
- backfill ran and produced exactly 4 rows per guild with correct legacy
  values; second run stayed at 8 rows (idempotent)
- `daily_goal <= 0` correctly rejected by the CHECK; deleting a guild
  cascades its goal rows

⚠️ The real `npm run db:push` + backfill must still be replayed against the
production database at deployment time (procedure above).

## Acceptance criteria (issue #18)

- [x] Table + backfill applicable via `npm run db:push` without interactive
  prompt on existing data (`--force`; verified non-interactive on an existing DB)
- [x] Every configured guild ends up with exactly 4 goal rows = its old `dailyGoal`
- [x] No behaviour change in this step (commands untouched)
