### PR TITLE
test: unit tests for pure logic with node:test (#15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,8 @@ jobs:
             - name: Lint (ESLint + Prettier)
               run: npx eslint .
 
+            - name: Unit tests (node --test)
+              run: npm test
+
             - name: Security audit (production deps)
               run: npm audit --omit=dev

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "scripts": {
         "start": "node --env-file=.env src/index.js",
         "deploy": "node --env-file=.env src/deploy-commands.js",
-        "db:push": "node --env-file=.env ./node_modules/drizzle-kit/bin.cjs push"
+        "db:push": "node --env-file=.env ./node_modules/drizzle-kit/bin.cjs push",
+        "test": "node --test \"test/**/*.test.js\""
     },
     "dependencies": {
         "discord.js": "^14.27.0",

--- a/src/commands/admin/setup.js
+++ b/src/commands/admin/setup.js
@@ -6,29 +6,12 @@ import {
 } from 'discord.js';
 import { DateTime } from 'luxon';
 import { setupGuild } from '../../db/queries.js';
+import {
+    reminderTimePattern,
+    resolveTimezoneInput,
+} from '../../utils/timezones.js';
 
-const reminderTimePattern = /^([01]\d|2[0-3]):[0-5]\d$/;
 const maxAutocompleteChoices = 10;
-
-function resolveTimezoneInput(input) {
-    const zone = DateTime.now().setZone(input);
-    if (zone.isValid) {
-        return { ok: true, timezone: zone.zoneName };
-    }
-
-    const needle = input.split('/').pop().toLowerCase();
-    const matches = Intl.supportedValuesOf('timeZone').filter(
-        (candidate) => candidate.split('/').pop().toLowerCase() === needle,
-    );
-
-    if (matches.length === 1) {
-        return { ok: true, timezone: matches[0] };
-    }
-    if (matches.length > 1) {
-        return { ok: false, candidates: matches };
-    }
-    return { ok: false, candidates: [] };
-}
 
 export const data = new SlashCommandBuilder()
     .setName('setup')

--- a/src/db/recap.js
+++ b/src/db/recap.js
@@ -1,35 +1,10 @@
 import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
-import { DateTime } from 'luxon';
 import { db } from './client.js';
 import { entries, guilds, participants } from './schema.js';
 import { dateInGuildTimezone } from './helpers.js';
+import { isRecapDue } from '../utils/recap-time.js';
 
-function isRecapDue(guild) {
-    const now = DateTime.now().setZone(guild.timezone);
-    const today = now.toISODate();
-
-    if (guild.lastRecapDate === today) {
-        return false;
-    }
-
-    if (now.toFormat('HH:mm') !== guild.reminderTime) {
-        return false;
-    }
-
-    if (guild.startDate) {
-        const lastDay = DateTime.fromISO(guild.startDate, {
-            zone: guild.timezone,
-        })
-            .plus({ days: guild.durationDays - 1 })
-            .toISODate();
-
-        if (today > lastDay) {
-            return false;
-        }
-    }
-
-    return true;
-}
+export { isRecapDue };
 
 export async function getDueRecapGuilds() {
     const configuredGuilds = await db

--- a/src/utils/recap-time.js
+++ b/src/utils/recap-time.js
@@ -1,0 +1,28 @@
+import { DateTime } from 'luxon';
+
+export function isRecapDue(guild, now = DateTime.now()) {
+    const guildNow = now.setZone(guild.timezone);
+    const today = guildNow.toISODate();
+
+    if (guild.lastRecapDate === today) {
+        return false;
+    }
+
+    if (guildNow.toFormat('HH:mm') !== guild.reminderTime) {
+        return false;
+    }
+
+    if (guild.startDate) {
+        const lastDay = DateTime.fromISO(guild.startDate, {
+            zone: guild.timezone,
+        })
+            .plus({ days: guild.durationDays - 1 })
+            .toISODate();
+
+        if (today > lastDay) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/utils/timezones.js
+++ b/src/utils/timezones.js
@@ -1,0 +1,26 @@
+import { DateTime } from 'luxon';
+
+export const reminderTimePattern = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export function resolveTimezoneInput(
+    input,
+    supportedZones = Intl.supportedValuesOf('timeZone'),
+) {
+    const zone = DateTime.now().setZone(input);
+    if (zone.isValid) {
+        return { ok: true, timezone: zone.zoneName };
+    }
+
+    const needle = input.split('/').pop().toLowerCase();
+    const matches = supportedZones.filter(
+        (candidate) => candidate.split('/').pop().toLowerCase() === needle,
+    );
+
+    if (matches.length === 1) {
+        return { ok: true, timezone: matches[0] };
+    }
+    if (matches.length > 1) {
+        return { ok: false, candidates: matches };
+    }
+    return { ok: false, candidates: [] };
+}

--- a/test/defaults-contract.test.js
+++ b/test/defaults-contract.test.js
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+    entries,
+    EXERCISE_TYPES,
+    guilds,
+    participants,
+} from '../src/db/schema.js';
+
+// Command fallbacks live as `?? <literal>` in setup's execute(); the schema
+// column defaults live on the drizzle table columns. This contract pins them
+// together so one cannot drift from the other. When #11 extracts src/config.js,
+// both sides of each assertion should switch to importing the shared constant.
+
+const setupSource = readFileSync(
+    new URL('../src/commands/admin/setup.js', import.meta.url),
+    'utf8',
+);
+
+function fallbackLiteral(optionName) {
+    const pattern = new RegExp(
+        String.raw`getString\('${optionName}'\) \?\? '([^']+)';`,
+    );
+    const match = setupSource.match(pattern);
+    assert.ok(match, `no ?? fallback found for option ${optionName}`);
+    return match[1];
+}
+
+function fallbackInteger(optionName) {
+    const pattern = new RegExp(
+        String.raw`getInteger\('${optionName}'\) \?\? (\d+);`,
+    );
+    const match = setupSource.match(pattern);
+    assert.ok(match, `no ?? fallback found for option ${optionName}`);
+    return Number(match[1]);
+}
+
+describe('defaults contract (commands <-> schema)', () => {
+    it('daily_goal fallback equals guilds.dailyGoal default', () => {
+        assert.equal(fallbackInteger('daily_goal'), 100);
+        assert.equal(guilds.dailyGoal.default, 100);
+        assert.equal(fallbackInteger('daily_goal'), guilds.dailyGoal.default);
+    });
+
+    it('duration_days fallback equals guilds.durationDays default', () => {
+        assert.equal(fallbackInteger('duration_days'), 30);
+        assert.equal(guilds.durationDays.default, 30);
+        assert.equal(
+            fallbackInteger('duration_days'),
+            guilds.durationDays.default,
+        );
+    });
+
+    it('timezone fallback equals guilds.timezone default', () => {
+        assert.equal(fallbackLiteral('timezone'), 'Europe/Paris');
+        assert.equal(guilds.timezone.default, 'Europe/Paris');
+        assert.equal(fallbackLiteral('timezone'), guilds.timezone.default);
+    });
+
+    it('reminder_time fallback equals guilds.reminderTime default', () => {
+        assert.equal(fallbackLiteral('reminder_time'), '20:00');
+        assert.equal(guilds.reminderTime.default, '20:00');
+        assert.equal(
+            fallbackLiteral('reminder_time'),
+            guilds.reminderTime.default,
+        );
+    });
+
+    it('exercise type default matches EXERCISE_TYPES.PUSHUP', () => {
+        assert.equal(entries.exerciseType.hasDefault, true);
+        assert.equal(entries.exerciseType.default, EXERCISE_TYPES.PUSHUP);
+    });
+
+    it('participants.active defaults to true', () => {
+        assert.equal(participants.active.hasDefault, true);
+        assert.equal(participants.active.default, true);
+    });
+
+    it('entries.count defaults to 0', () => {
+        assert.equal(entries.count.hasDefault, true);
+        assert.equal(entries.count.default, 0);
+    });
+
+    it('every command fallback is a value the matching column accepts', () => {
+        // reminder_time must satisfy the HH:mm pattern used at validation time
+        const reminderPattern = /^([01]\d|2[0-3]):[0-5]\d$/;
+        assert.match(guilds.reminderTime.default, reminderPattern);
+
+        // timezone fallback must be a resolvable IANA zone
+        assert.equal(
+            Intl.supportedValuesOf('timeZone').includes('Europe/Paris'),
+            true,
+        );
+    });
+});

--- a/test/recap-time.test.js
+++ b/test/recap-time.test.js
@@ -1,0 +1,120 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { DateTime } from 'luxon';
+import { isRecapDue } from '../src/utils/recap-time.js';
+
+// Guild observed in Asia/Tokyo so tests never depend on the runner's TZ.
+const baseGuild = {
+    timezone: 'Asia/Tokyo',
+    reminderTime: '20:00',
+    lastRecapDate: null,
+    startDate: '2026-08-01',
+    durationDays: 30,
+};
+
+function atUtc(hours, minutes) {
+    return DateTime.utc(2026, 8, 26, hours, minutes);
+}
+
+describe('isRecapDue', () => {
+    it('is due at the exact reminder minute in the guild timezone', () => {
+        // UTC 11:00 == Tokyo 20:00
+        assert.equal(isRecapDue(baseGuild, atUtc(11, 0)), true);
+    });
+
+    it('evaluates the clock in the guild timezone, not server time', () => {
+        // UTC 13:00 == Tokyo 22:00 -> past the reminder window
+        assert.equal(isRecapDue(baseGuild, atUtc(13, 0)), false);
+        // Same instant expressed with a DateTime already set to Tokyo
+        const tokyoNow = atUtc(11, 0).setZone('Asia/Tokyo');
+        assert.equal(isRecapDue({ ...baseGuild }, tokyoNow), true);
+    });
+
+    it('is not due one minute before or after', () => {
+        assert.equal(isRecapDue(baseGuild, atUtc(10, 59)), false);
+        assert.equal(isRecapDue(baseGuild, atUtc(12, 1)), false);
+        // same day, different hour entirely
+        assert.equal(isRecapDue(baseGuild, atUtc(3, 15)), false);
+    });
+
+    it('is not due when lastRecapDate equals today (guild tz)', () => {
+        const sent = { ...baseGuild, lastRecapDate: '2026-08-26' };
+        assert.equal(isRecapDue(sent, atUtc(11, 0)), false);
+        // a recap from yesterday does not block today's recap
+        const stale = { ...baseGuild, lastRecapDate: '2026-08-25' };
+        assert.equal(isRecapDue(stale, atUtc(11, 0)), true);
+    });
+
+    it('compares lastRecapDate against the guild-tz date, not the server date', () => {
+        // UTC 11:00 on Aug 26 is still Aug 26 20:00 in Tokyo...
+        // but at UTC 15:30 (Tokyo 00:30 Aug 27) "today" rolls over.
+        const rolledOver = { ...baseGuild, lastRecapDate: '2026-08-26' };
+        assert.equal(
+            isRecapDue(rolledOver, DateTime.utc(2026, 8, 26, 15, 30)),
+            false,
+        ); // now Aug 27 in Tokyo, 00:30 != 20:00 anyway
+
+        const dueNextDay = {
+            ...baseGuild,
+            lastRecapDate: '2026-08-26',
+            reminderTime: '00:30',
+        };
+        assert.equal(
+            isRecapDue(dueNextDay, DateTime.utc(2026, 8, 26, 15, 30)),
+            true,
+        );
+    });
+
+    it('is due on the first and last day of the challenge window', () => {
+        // start 2026-08-01 + 30 days => last day 2026-08-30
+        const firstDay = DateTime.utc(2026, 8, 1, 11, 0);
+        assert.equal(isRecapDue(baseGuild, firstDay), true);
+
+        const lastDay = DateTime.utc(2026, 8, 30, 11, 0);
+        assert.equal(isRecapDue(baseGuild, lastDay), true);
+    });
+
+    it('is not due after the challenge window ends', () => {
+        const afterWindow = DateTime.utc(2026, 8, 31, 11, 0);
+        assert.equal(isRecapDue(baseGuild, afterWindow), false);
+
+        const wayAfter = DateTime.utc(2027, 1, 5, 11, 0);
+        assert.equal(isRecapDue(baseGuild, wayAfter), false);
+    });
+
+    it('ignores the window when startDate is null', () => {
+        const noStart = { ...baseGuild, startDate: null };
+        assert.equal(
+            isRecapDue(noStart, DateTime.utc(2030, 1, 1, 11, 0)),
+            true,
+        );
+    });
+
+    it('still checks time-of-day when startDate is null', () => {
+        const noStart = { ...baseGuild, startDate: null };
+        assert.equal(
+            isRecapDue(noStart, DateTime.utc(2030, 1, 1, 9, 0)),
+            false,
+        );
+    });
+
+    it('fires at 20:00 sharp on a DST spring-forward day', () => {
+        // Europe/Paris switched 02:00->03:00 on 2027-03-28; 20:00 local exists
+        const springGuild = {
+            ...baseGuild,
+            timezone: 'Europe/Paris',
+            startDate: '2027-03-01',
+        };
+        const due = DateTime.fromISO('2027-03-28T20:00', {
+            zone: 'Europe/Paris',
+        });
+        assert.equal(isRecapDue(springGuild, due), true);
+        // the skipped wall-clock slot collapses forward: local 02:30 becomes 03:30
+        const collapsed = DateTime.fromISO('2027-03-28T02:30', {
+            zone: 'Europe/Paris',
+        });
+        assert.equal(collapsed.hour, 3);
+        const gapReminder = { ...springGuild, reminderTime: '02:30' };
+        assert.equal(isRecapDue(gapReminder, collapsed), false);
+    });
+});

--- a/test/timezones.test.js
+++ b/test/timezones.test.js
@@ -1,0 +1,190 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    reminderTimePattern,
+    resolveTimezoneInput,
+} from '../src/utils/timezones.js';
+
+describe('resolveTimezoneInput', () => {
+    describe('city name -> IANA resolution', () => {
+        it('resolves a city name to its IANA zone', () => {
+            assert.deepEqual(resolveTimezoneInput('Paris'), {
+                ok: true,
+                timezone: 'Europe/Paris',
+            });
+            assert.deepEqual(resolveTimezoneInput('Tokyo'), {
+                ok: true,
+                timezone: 'Asia/Tokyo',
+            });
+        });
+
+        it('is case-insensitive on the city name', () => {
+            assert.equal(
+                resolveTimezoneInput('PARIS').timezone,
+                'Europe/Paris',
+            );
+            assert.equal(resolveTimezoneInput('tOkYo').ok, true);
+        });
+
+        it('matches only on the last path segment of candidate zones', () => {
+            // 'Foo/New_York' is not a valid zone but its tail 'new_york'
+            // uniquely matches America/New_York (case-insensitive)
+            const result = resolveTimezoneInput('Foo/New_York');
+            assert.deepEqual(result, {
+                ok: true,
+                timezone: 'America/New_York',
+            });
+        });
+    });
+
+    describe('full IANA passthrough', () => {
+        it('accepts a complete IANA name as-is', () => {
+            assert.deepEqual(resolveTimezoneInput('America/New_York'), {
+                ok: true,
+                timezone: 'America/New_York',
+            });
+            assert.deepEqual(resolveTimezoneInput('Europe/Paris'), {
+                ok: true,
+                timezone: 'Europe/Paris',
+            });
+        });
+
+        it('accepts UTC and fixed offsets without lookup', () => {
+            assert.deepEqual(resolveTimezoneInput('UTC'), {
+                ok: true,
+                timezone: 'UTC',
+            });
+            assert.deepEqual(resolveTimezoneInput('+05:00'), {
+                ok: true,
+                timezone: '+05:00',
+            });
+        });
+
+        it('normalizes a bare city that is itself an alias zone', () => {
+            // 'Singapore' resolves directly (alias) instead of Asia/Singapore
+            assert.equal(resolveTimezoneInput('Singapore').ok, true);
+        });
+
+        it('keeps lowercase-with-slash input verbatim (passthrough)', () => {
+            // Luxon accepts it; zoneName echoes the given casing
+            assert.deepEqual(resolveTimezoneInput('europe/paris'), {
+                ok: true,
+                timezone: 'europe/paris',
+            });
+        });
+
+        it('resolves through an unknown directory prefix via tail match', () => {
+            // 'Foo/Paris' is not a valid zone but 'paris' matches Europe/Paris
+            assert.deepEqual(resolveTimezoneInput('Foo/Paris'), {
+                ok: true,
+                timezone: 'Europe/Paris',
+            });
+        });
+    });
+
+    describe('unknown zone', () => {
+        it('rejects an unknown city with no candidates', () => {
+            assert.deepEqual(resolveTimezoneInput('Atlantis/City'), {
+                ok: false,
+                candidates: [],
+            });
+            assert.deepEqual(resolveTimezoneInput('Nowhereville'), {
+                ok: false,
+                candidates: [],
+            });
+        });
+
+        it('rejects empty and malformed inputs', () => {
+            assert.deepEqual(resolveTimezoneInput(''), {
+                ok: false,
+                candidates: [],
+            });
+            assert.deepEqual(resolveTimezoneInput('Paris/Foo'), {
+                ok: false,
+                candidates: [],
+            });
+            assert.deepEqual(resolveTimezoneInput('Paris/'), {
+                ok: false,
+                candidates: [],
+            });
+        });
+    });
+
+    describe('ambiguity branch', () => {
+        it('returns every matching candidate when several zones share a tail', () => {
+            const synthetic = [
+                'America/Springfield',
+                'US/Springfield',
+                'Europe/Paris',
+            ];
+            assert.deepEqual(resolveTimezoneInput('Springfield', synthetic), {
+                ok: false,
+                candidates: ['America/Springfield', 'US/Springfield'],
+            });
+        });
+
+        it('returns the unique candidate when only one zone matches', () => {
+            const synthetic = ['Europe/Paris', 'Asia/Tokyo'];
+            assert.deepEqual(resolveTimezoneInput('tokyo', synthetic), {
+                ok: true,
+                timezone: 'Asia/Tokyo',
+            });
+        });
+
+        it('falls back to tail search when the direct input is invalid', () => {
+            const synthetic = ['Europe/Paris', 'Europe/London'];
+            // 'london' alone is not resolvable by Luxon but has one tail match
+            assert.deepEqual(resolveTimezoneInput('London', synthetic), {
+                ok: true,
+                timezone: 'Europe/London',
+            });
+        });
+
+        it('defaults to the full Intl supported list', () => {
+            const result = resolveTimezoneInput('Paris');
+            assert.deepEqual(result, { ok: true, timezone: 'Europe/Paris' });
+        });
+    });
+});
+
+describe('reminderTimePattern', () => {
+    it('accepts valid HH:mm values across bounds', () => {
+        const valid = [
+            '00:00',
+            '00:59',
+            '09:05',
+            '10:00',
+            '19:59',
+            '20:00',
+            '23:59',
+        ];
+        for (const time of valid) {
+            assert.equal(reminderTimePattern.test(time), true, time);
+        }
+    });
+
+    it('rejects 24:00 and out-of-range hours', () => {
+        const invalid = ['24:00', '24:01', '25:30', '99:99'];
+        for (const time of invalid) {
+            assert.equal(reminderTimePattern.test(time), false, time);
+        }
+    });
+
+    it('rejects single-digit hours like 7:30', () => {
+        assert.equal(reminderTimePattern.test('7:30'), false);
+        assert.equal(reminderTimePattern.test('7:00'), false);
+    });
+
+    it('rejects malformed minutes', () => {
+        const invalid = ['20:5', '20:', ':30', '20:60', '20:00x', '', '2000'];
+        for (const time of invalid) {
+            assert.equal(reminderTimePattern.test(time), false, time);
+        }
+    });
+
+    it('rejects separators other than colon', () => {
+        assert.equal(reminderTimePattern.test('20.00'), false);
+        assert.equal(reminderTimePattern.test('20 00'), false);
+        assert.equal(reminderTimePattern.test('20h00'), false);
+    });
+});


### PR DESCRIPTION
Closes #15

## Quoi

Tests unitaires avec le runner natif `node:test` (zéro nouvelle dépendance) sur la logique pure, plus le test de contrat des defaults demandé en commentaire d'issue.

## Refactors minimes (extraction pour éviter toute connexion DB dans les tests)

- `src/utils/timezones.js` : `resolveTimezoneInput()` + `reminderTimePattern`, extraits de `src/commands/admin/setup.js` (qui importe transitivement `db/client.js` via le barrel `db/queries.js`). La liste des zones supportées est injectable (`supportedZones` paramètre avec défaut `Intl.supportedValuesOf('timeZone')`) pour rendre la branche d'ambiguïté testable. `setup.js` ré-importe depuis le module utilitaire — comportement inchangé.
- `src/utils/recap-time.js` : `isRecapDue(guild, now?)` extraite de `src/db/recap.js`, avec un paramètre `now` optionnel (défaut `DateTime.now()`) pour des tests déterministes sans muter l'horloge globale. `recap.js` ré-exporte la fonction — aucun import existant cassé.

## Couverture (37 tests, 8 suites)

1. **resolveTimezoneInput** — ville → IANA (`Paris` → `Europe/Paris`), IANA complet passthrough, lowercase-avec-slash, zone inconnue / entrées malformées, branche d'ambiguïté (via injection d'une liste synthétique, la vraie liste n'ayant aucune queue dupliquée).
2. **isRecapDue** — match minute exacte dans le fuseau du serveur (vérifié en `Asia/Tokyo`, indépendant de la TZ du runner), `lastRecapDate == today`, avant/après la fenêtre du challenge (premier/dernier jour inclus), `startDate` null, edge DST (jour du passage à l'heure d'été 2027 à Paris).
3. **reminderTimePattern** — bornes HH:mm valides (`00:00`…`23:59`), `24:00` rejeté, `7:30` rejeté, minutes/secondes/séparateurs malformés rejetés.
4. **Contrat des defaults** (demande owner en commentaire d'issue) — chaque fallback de commande (`?? 100`, `?? 30`, `?? 'Europe/Paris'`, `?? '20:00'`) strictement égal au default de la colonne schema correspondante (`guilds.dailyGoal/durationDays/timezone/reminderTime`), plus defaults `entries.exerciseType === EXERCISE_TYPES.PUSHUP`, `participants.active === true`, `entries.count === 0`. Quand #11 livrera `src/config.js`, les deux côtés devront pointer vers la constante partagée (noté dans le test).

## CI

- `package.json` : ajout de `"test": "node --test \"test/**/*.test.js\""` (start/deploy/db:push inchangés).
- `.github/workflows/ci.yml` : step `npm test` entre le lint et l'audit.

## Validation locale

```
ℹ tests 37
ℹ suites 8
ℹ pass 37
ℹ fail 0
```

- `npm test` vert localement (Node v26) et avec `env -u DATABASE_URL -u DISCORD_TOKEN` : aucun test ne requiert ces variables.
- Aucun fichier de test n'importe un module ouvrant une connexion DB.
- `npx eslint .` vert, y compris sur les fichiers de test.

## ⚠️ PR empilée

**Cette PR cible la branche `refactor/split-db-queries-by-concern` (PR #24), PAS `master`.**
Elle doit être mergée **APRÈS** #24. Si #24 est modifiée, il faudra rebase cette branche dessus.
