### PR TITLE
chore: DRY exercise choices, centralize defaults, log rotation, graceful shutdown

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -2,6 +2,10 @@ services:
     bot:
         build: .
         restart: unless-stopped
+        logging:
+            driver: json-file
+            options:
+                max-size: 10m
         environment:
             APP_ID: ${APP_ID}
             DISCORD_TOKEN: ${DISCORD_TOKEN}
@@ -13,6 +17,10 @@ services:
     db:
         image: postgres:17-alpine
         restart: unless-stopped
+        logging:
+            driver: json-file
+            options:
+                max-size: 10m
         environment:
             POSTGRES_USER: ${POSTGRES_USER}
             POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -25,6 +33,10 @@ services:
     db-backup:
         image: postgres:17-alpine
         restart: unless-stopped
+        logging:
+            driver: json-file
+            options:
+                max-size: 10m
         depends_on:
             - db
         environment:

--- a/src/commands/admin/admin-log.js
+++ b/src/commands/admin/admin-log.js
@@ -7,13 +7,8 @@ import {
     adminAddExercise,
     adminRemoveExercise,
     adminSetExercise,
-    EXERCISE_TYPES,
 } from '../../db/queries.js';
-
-const exerciseChoices = Object.values(EXERCISE_TYPES).map((exerciseType) => ({
-    name: exerciseType,
-    value: exerciseType,
-}));
+import { exerciseChoices } from '../../utils/exercises.js';
 
 function addUserExerciseAmountOptions(command, amountName) {
     return command

--- a/src/commands/challenge/leaderboard.js
+++ b/src/commands/challenge/leaderboard.js
@@ -1,10 +1,6 @@
 import { MessageFlags, SlashCommandBuilder } from 'discord.js';
-import { EXERCISE_TYPES, getLeaderboard } from '../../db/queries.js';
-
-const exerciseChoices = Object.values(EXERCISE_TYPES).map((exerciseType) => ({
-    name: exerciseType,
-    value: exerciseType,
-}));
+import { getLeaderboard } from '../../db/queries.js';
+import { exerciseChoices } from '../../utils/exercises.js';
 
 export const data = new SlashCommandBuilder()
     .setName('leaderboard')

--- a/src/commands/challenge/log.js
+++ b/src/commands/challenge/log.js
@@ -1,10 +1,6 @@
 import { MessageFlags, SlashCommandBuilder } from 'discord.js';
-import { addExercise, EXERCISE_TYPES, setExercise } from '../../db/queries.js';
-
-const exerciseChoices = Object.values(EXERCISE_TYPES).map((exerciseType) => ({
-    name: exerciseType,
-    value: exerciseType,
-}));
+import { addExercise, setExercise } from '../../db/queries.js';
+import { exerciseChoices } from '../../utils/exercises.js';
 
 function addExerciseOption(command) {
     return command.addStringOption((option) =>

--- a/src/commands/challenge/stats.js
+++ b/src/commands/challenge/stats.js
@@ -6,11 +6,7 @@ import {
     getUserStats,
     getUserStreak,
 } from '../../db/queries.js';
-
-const exerciseChoices = Object.values(EXERCISE_TYPES).map((exerciseType) => ({
-    name: exerciseType,
-    value: exerciseType,
-}));
+import { exerciseChoices } from '../../utils/exercises.js';
 
 function addExerciseOption(command, { required = true } = {}) {
     return command.addStringOption((option) =>

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,5 @@
+export const DEFAULT_TIMEZONE = 'Europe/Paris';
+export const DEFAULT_REMINDER_TIME = '20:00';
+export const DEFAULT_DAILY_GOAL = 100;
+export const DEFAULT_DURATION_DAYS = 30;
+export const DEFAULT_COOLDOWN_SECONDS = 3;

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -12,6 +12,12 @@ import {
     primaryKey,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
+import {
+    DEFAULT_DAILY_GOAL,
+    DEFAULT_DURATION_DAYS,
+    DEFAULT_REMINDER_TIME,
+    DEFAULT_TIMEZONE,
+} from '../config.js';
 
 export const EXERCISE_TYPES = {
     PUSHUP: 'PUSHUP',
@@ -29,15 +35,19 @@ export const guilds = pgTable('guilds', {
     guildId: text('guild_id').primaryKey(),
     trackedChannelId: text('tracked_channel_id'),
     startDate: date('start_date'),
-    durationDays: integer('duration_days').notNull().default(30),
+    durationDays: integer('duration_days')
+        .notNull()
+        .default(DEFAULT_DURATION_DAYS),
     /**
      * @deprecated Since issue #18. Replaced by the per-exercise goals in
      * `guildExerciseGoals`; stop reading/writing this column when UX v2
      * (#19) ships. Drop deferred.
      */
-    dailyGoal: integer('daily_goal').notNull().default(100),
-    timezone: text('timezone').notNull().default('Europe/Paris'),
-    reminderTime: text('reminder_time').notNull().default('20:00'),
+    dailyGoal: integer('daily_goal').notNull().default(DEFAULT_DAILY_GOAL),
+    timezone: text('timezone').notNull().default(DEFAULT_TIMEZONE),
+    reminderTime: text('reminder_time')
+        .notNull()
+        .default(DEFAULT_REMINDER_TIME),
     lastRecapDate: date('last_recap_date'),
     /**
      * Marker set once the end-of-challenge message has been posted (#20).

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -1,4 +1,5 @@
 import { Collection, Events, MessageFlags } from 'discord.js';
+import { DEFAULT_COOLDOWN_SECONDS } from '../../config.js';
 
 export const name = Events.InteractionCreate;
 
@@ -24,7 +25,7 @@ export async function execute(interaction) {
 
         const now = Date.now();
         const timestamps = cooldowns.get(command.data.name);
-        const defaultCooldownDuration = 3;
+        const defaultCooldownDuration = DEFAULT_COOLDOWN_SECONDS;
         const cooldownAmount =
             (command.cooldown ?? defaultCooldownDuration) * 1_000;
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,5 +40,14 @@ for (const file of eventFiles) {
     }
 }
 
+// --- Graceful shutdown ---
+for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => {
+        console.log(`Received ${signal}, shutting down...`);
+        client.destroy();
+        process.exit(0);
+    });
+}
+
 // --- Connect ---
 client.login(process.env.DISCORD_TOKEN);

--- a/src/utils/exercises.js
+++ b/src/utils/exercises.js
@@ -1,0 +1,8 @@
+import { EXERCISE_TYPES } from '../db/schema.js';
+
+export const exerciseChoices = Object.values(EXERCISE_TYPES).map(
+    (exerciseType) => ({
+        name: exerciseType,
+        value: exerciseType,
+    }),
+);


### PR DESCRIPTION
Closes #11

Batch de 4 cleanups behaviour-neutral (zéro change user-facing, zéro DB change) :

1. **DRY exerciseChoices** — le mapping `EXERCISE_TYPES` → choices Discord, dupliqué dans `log.js`, `leaderboard.js`, `stats.js` et `admin-log.js`, est factorisé dans `src/utils/exercises.js`. Ajouter un exercice à `EXERCISE_TYPES` ne nécessite plus que 1 edit.
2. **Defaults centralisés** — nouveau module feuille `src/config.js` (`DEFAULT_TIMEZONE`, `DEFAULT_REMINDER_TIME`, `DEFAULT_DAILY_GOAL`, `DEFAULT_DURATION_DAYS`, `DEFAULT_COOLDOWN_SECONDS`), consommé par les fallbacks de `setup.js`, les defaults de colonnes de `schema.js` (drizzle accepte une constante importée) et le cooldown par défaut d'`interactionCreate.js`. Aucune dépendance dans config.js ⇒ pas d'imports circulaires.
3. **Log rotation Docker** — driver `json-file` avec `max-size: 10m` sur chaque service de `compose.yml` (bot, db, db-backup).
4. **Graceful shutdown** — handlers SIGINT/SIGTERM dans `src/index.js` : `client.destroy()` + `process.exit(0)`.

Valeurs des defaults strictement identiques (Europe/Paris, 20:00, 100, 30, 3).

✅ `npx eslint .` vert · ✅ `node --check` sur tous les fichiers touchés · ✅ `docker compose config -q` OK
