### PR TITLE
fix: rattrapage du récap quotidien quand le bot était down à l'heure de reminder

### DIFF
--- a/src/db/recap.js
+++ b/src/db/recap.js
@@ -12,7 +12,9 @@ export async function getDueRecapGuilds() {
         .from(guilds)
         .where(isNotNull(guilds.trackedChannelId));
 
-    return configuredGuilds.filter(isRecapDue);
+    // filter passes (element, index, array): a bare isRecapDue reference
+    // would receive the index as `now` and crash on now.setZone.
+    return configuredGuilds.filter((guild) => isRecapDue(guild));
 }
 
 export async function getDailyProgress(guild) {

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -4,6 +4,7 @@ import {
     getDueRecapGuilds,
     markRecapSent,
 } from './db/queries.js';
+import { isRecapLate } from './utils/recap-time.js';
 
 function buildRecapMessage(guild, progress) {
     const lines = progress.rows.map((row) => {
@@ -15,7 +16,11 @@ function buildRecapMessage(guild, progress) {
         return `<@${row.userId}> : ${row.total}/${guild.dailyGoal} — ${status}`;
     });
 
-    return [`Récap du jour (${progress.entryDate}) :`, ...lines].join('\n');
+    const lateTag = isRecapLate(guild) ? '(en retard) ' : '';
+
+    return [`Récap du jour ${lateTag}(${progress.entryDate}) :`, ...lines].join(
+        '\n',
+    );
 }
 
 async function sendDueRecaps(client) {

--- a/src/utils/recap-time.js
+++ b/src/utils/recap-time.js
@@ -1,5 +1,11 @@
 import { DateTime } from 'luxon';
 
+function minutesOfDay(time) {
+    const [hour, minute] = time.split(':').map(Number);
+
+    return hour * 60 + minute;
+}
+
 export function isRecapDue(guild, now = DateTime.now()) {
     const guildNow = now.setZone(guild.timezone);
     const today = guildNow.toISODate();
@@ -8,7 +14,16 @@ export function isRecapDue(guild, now = DateTime.now()) {
         return false;
     }
 
-    if (guildNow.toFormat('HH:mm') !== guild.reminderTime) {
+    // #13: due AT the reminder minute or at any later minute of the same
+    // guild-tz day, so a bot downtime no longer loses the recap. Edge case,
+    // documented choice: a guild configured TODAY with its reminder time
+    // already past fires a same-day catch-up (rather than skipping to
+    // tomorrow). Multi-day downtime still yields exactly one recap, for
+    // today only, because only `today` is ever evaluated.
+    if (
+        guildNow.hour * 60 + guildNow.minute <
+        minutesOfDay(guild.reminderTime)
+    ) {
         return false;
     }
 
@@ -25,4 +40,12 @@ export function isRecapDue(guild, now = DateTime.now()) {
     }
 
     return true;
+}
+
+export function isRecapLate(guild, now = DateTime.now()) {
+    const guildNow = now.setZone(guild.timezone);
+
+    return (
+        guildNow.hour * 60 + guildNow.minute > minutesOfDay(guild.reminderTime)
+    );
 }

--- a/test/recap-time.test.js
+++ b/test/recap-time.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { DateTime } from 'luxon';
-import { isRecapDue } from '../src/utils/recap-time.js';
+import { isRecapDue, isRecapLate } from '../src/utils/recap-time.js';
 
 // Guild observed in Asia/Tokyo so tests never depend on the runner's TZ.
 const baseGuild = {
@@ -23,16 +23,23 @@ describe('isRecapDue', () => {
     });
 
     it('evaluates the clock in the guild timezone, not server time', () => {
-        // UTC 13:00 == Tokyo 22:00 -> past the reminder window
-        assert.equal(isRecapDue(baseGuild, atUtc(13, 0)), false);
+        // Behavior changed with #13: any instant past the reminder minute is
+        // due, so UTC 13:00 (Tokyo 22:00) is now due — which itself proves
+        // the comparison runs on Tokyo wall time, not UTC 20:00.
+        assert.equal(isRecapDue(baseGuild, atUtc(13, 0)), true);
+        // A pre-reminder Tokyo instant stays not due regardless of how the
+        // server clock reads it: UTC 03:00 == Tokyo 12:00.
+        assert.equal(isRecapDue(baseGuild, atUtc(3, 0)), false);
         // Same instant expressed with a DateTime already set to Tokyo
         const tokyoNow = atUtc(11, 0).setZone('Asia/Tokyo');
         assert.equal(isRecapDue({ ...baseGuild }, tokyoNow), true);
     });
 
-    it('is not due one minute before or after', () => {
+    it('is due one minute after the reminder (catch-up), not before', () => {
+        // Behavior changed with #13: the old exact-equality rule lost the
+        // recap whenever the bot was not running at the precise minute.
         assert.equal(isRecapDue(baseGuild, atUtc(10, 59)), false);
-        assert.equal(isRecapDue(baseGuild, atUtc(12, 1)), false);
+        assert.equal(isRecapDue(baseGuild, atUtc(12, 1)), true);
         // same day, different hour entirely
         assert.equal(isRecapDue(baseGuild, atUtc(3, 15)), false);
     });
@@ -74,11 +81,13 @@ describe('isRecapDue', () => {
         assert.equal(isRecapDue(baseGuild, lastDay), true);
     });
 
-    it('is not due after the challenge window ends', () => {
-        const afterWindow = DateTime.utc(2026, 8, 31, 11, 0);
+    it('is not due after the challenge window ends, even past the reminder', () => {
+        // Post-reminder instants (Tokyo 22:37): they would trigger a #13
+        // catch-up if the window were open, so this pins the window check.
+        const afterWindow = DateTime.utc(2026, 8, 31, 13, 37);
         assert.equal(isRecapDue(baseGuild, afterWindow), false);
 
-        const wayAfter = DateTime.utc(2027, 1, 5, 11, 0);
+        const wayAfter = DateTime.utc(2027, 1, 5, 13, 37);
         assert.equal(isRecapDue(baseGuild, wayAfter), false);
     });
 
@@ -115,6 +124,96 @@ describe('isRecapDue', () => {
         });
         assert.equal(collapsed.hour, 3);
         const gapReminder = { ...springGuild, reminderTime: '02:30' };
-        assert.equal(isRecapDue(gapReminder, collapsed), false);
+        // Behavior changed with #13: the skipped 02:30 slot collapses to
+        // 03:30, strictly after the reminder, so the day is salvaged by a
+        // late catch-up instead of being silently lost.
+        assert.equal(isRecapDue(gapReminder, collapsed), true);
+    });
+
+    it('catches up when the bot comes back after the reminder time (#13)', () => {
+        // UTC 13:37 == Tokyo 22:37: the 20:00 slot was missed entirely
+        assert.equal(isRecapDue(baseGuild, atUtc(13, 37)), true);
+
+        const sentYesterday = { ...baseGuild, lastRecapDate: '2026-08-25' };
+        assert.equal(isRecapDue(sentYesterday, atUtc(13, 37)), true);
+    });
+
+    it('is not due once already sent today, even far after the reminder', () => {
+        // Tokyo 23:59, almost four hours past the reminder: the once-per-day
+        // guard wins over the catch-up rule.
+        const sent = { ...baseGuild, lastRecapDate: '2026-08-26' };
+        assert.equal(isRecapDue(sent, atUtc(14, 59)), false);
+    });
+
+    it('is not due before the reminder time, however early', () => {
+        // Tokyo 19:59, one minute early
+        assert.equal(isRecapDue(baseGuild, atUtc(10, 59)), false);
+        // Tokyo 08:00 the same morning
+        assert.equal(
+            isRecapDue(baseGuild, DateTime.utc(2026, 8, 25, 23, 0)),
+            false,
+        );
+    });
+
+    it('sends exactly one catch-up after several offline days (#13)', () => {
+        const stale = { ...baseGuild, lastRecapDate: '2026-08-22' };
+        // Back online 2026-08-26 after the reminder: due for TODAY only —
+        // no backlog replay of Aug 23-25, because only `today` is evaluated.
+        assert.equal(isRecapDue(stale, atUtc(13, 0)), true);
+    });
+
+    it('fires a same-day catch-up when configured after the reminder passed', () => {
+        // Documented edge case (#13): the guild is set up today with a 09:00
+        // reminder that is already past at 11:00 — we fire rather than wait
+        // for tomorrow.
+        const fresh = { ...baseGuild, reminderTime: '09:00' };
+        // UTC 02:00 == Tokyo 11:00
+        assert.equal(isRecapDue(fresh, atUtc(2, 0)), true);
+        // ...but nothing fires before that first reminder (Tokyo 08:59)
+        assert.equal(
+            isRecapDue(fresh, DateTime.utc(2026, 8, 25, 23, 59)),
+            false,
+        );
+    });
+
+    it('does not recap after midnight before the next reminder (#13)', () => {
+        // UTC 15:30 == Tokyo 00:30 on Aug 27: the Aug 27 reminder has not
+        // passed yet and the Aug 26 one belongs to a finished calendar day.
+        assert.equal(isRecapDue(baseGuild, atUtc(15, 30)), false);
+    });
+
+    it('recaps late on the last window day, never after it (#13)', () => {
+        // Last day 2026-08-30, very late catch-up (Tokyo 23:59) still counts
+        assert.equal(
+            isRecapDue(baseGuild, DateTime.utc(2026, 8, 30, 14, 59)),
+            true,
+        );
+
+        // Day after last day: not due at either end of the guild-tz day
+        const earlyTokyo = DateTime.utc(2026, 8, 30, 15, 30); // 00:30 Aug 31
+        assert.equal(isRecapDue(baseGuild, earlyTokyo), false);
+        assert.equal(
+            isRecapDue(baseGuild, DateTime.utc(2026, 8, 31, 14, 59)),
+            false,
+        ); // Tokyo 23:59 Aug 31
+    });
+});
+
+describe('isRecapLate', () => {
+    it('is not late at the exact reminder minute', () => {
+        assert.equal(isRecapLate(baseGuild, atUtc(11, 0)), false);
+    });
+
+    it('is late strictly after the reminder minute', () => {
+        assert.equal(isRecapLate(baseGuild, atUtc(11, 1)), true);
+        assert.equal(isRecapLate(baseGuild, atUtc(14, 59)), true);
+    });
+
+    it('is not late before the reminder minute', () => {
+        assert.equal(isRecapLate(baseGuild, atUtc(10, 59)), false);
+        assert.equal(
+            isRecapLate(baseGuild, DateTime.utc(2026, 8, 25, 23, 0)),
+            false,
+        );
     });
 });


### PR DESCRIPTION
Closes #13

## Problème
`isRecapDue` exigeait une égalité exacte `HH:mm` avec l'heure de reminder. Si le bot était down (redémarrage, crash, déploiement) pendant cette minute précise, le récap du jour était perdu — aucun rattrapage.

## Changements
- **`src/utils/recap-time.js`** : comparaison en minutes-du-jour (`>=`) au lieu d'une égalité stricte. Due à la minute du reminder **ou toute minute ultérieure** du même jour (fuseau de la guilde). Garde-fous inchangés : un récap max par jour calendaire (`lastRecapDate`) et fenêtre du défi (`startDate` + `durationDays`). Cas edge documenté en commentaire : une guilde créée aujourd'hui avec le reminder déjà passé déclenche un rattrapage le jour même. Downtime multi-jours = 1 seul récap, pour aujourd'hui uniquement.
- **`src/db/recap.js`** : fix bug latent — `.filter(isRecapDue)` recevait l'index du tableau comme paramètre `now` (`Array.filter` passe `(element, index, array)`) → TypeError à chaque tick cron. → `.filter((guild) => isRecapDue(guild))`.
- **`src/scheduler.js`** : header `Récap du jour (en retard) (...)` quand on poste après la minute du reminder, via nouveau helper pur `isRecapLate` (`>` strict). Le `markRecapSent` reste après le send (garde anti double-envoi entre deux ticks rapprochés).

## Tests
47 tests verts (37 avant), eslint 0 problème :
- rattrapage après downtime (> reminderTime), envoi unique par jour, pré-reminder non dû
- downtime multi-jours → 1 récap du jour seulement, pas de replay
- setup le jour même après l'heure de reminder, rollover minuit, bornes de fenêtre
- DST spring-forward : le créneau sauté produit désormais un rattrapage au lieu de perdre le jour
- `isRecapLate` : exact = false, +1 min = true, avant = false

**PR empilée sur #15 (`feat/issue-15-unit-tests`)** — merger #15 d'abord.
