### PR TITLE
feat: end-of-challenge message with podium posted once via scheduler (#20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "scripts": {
         "start": "node --env-file=.env src/index.js",
         "deploy": "node --env-file=.env src/deploy-commands.js",
+        "test": "node --test",
         "db:push": "node --env-file=.env ./node_modules/drizzle-kit/bin.cjs push"
     },
     "dependencies": {

--- a/src/db/challenge-end.js
+++ b/src/db/challenge-end.js
@@ -1,0 +1,93 @@
+import { and, desc, eq, gte, isNotNull, isNull, lte, sql } from 'drizzle-orm';
+import { db } from './client.js';
+import { entries, guildExerciseGoals, guilds, participants } from './schema.js';
+import {
+    getChallengeWindow,
+    isChallengeEnded,
+} from '../utils/challenge-end.js';
+
+export async function getGuildsForChallengeEnd() {
+    const configuredGuilds = await db
+        .select()
+        .from(guilds)
+        .where(
+            and(
+                isNotNull(guilds.trackedChannelId),
+                isNull(guilds.challengeEndedAt),
+                isNotNull(guilds.startDate),
+            ),
+        );
+
+    return configuredGuilds.filter((guild) => isChallengeEnded(guild));
+}
+
+export async function getDailyGoalTarget(guild) {
+    const [row] = await db
+        .select({
+            total: sql`coalesce(sum(${guildExerciseGoals.dailyGoal}), 0)`.mapWith(
+                Number,
+            ),
+        })
+        .from(guildExerciseGoals)
+        .where(eq(guildExerciseGoals.guildId, guild.guildId));
+
+    const perExerciseSum = row?.total ?? 0;
+
+    return perExerciseSum > 0 ? perExerciseSum : guild.dailyGoal;
+}
+
+export async function getChallengeResults(guild) {
+    const window = getChallengeWindow(guild);
+
+    if (!window) {
+        return { ok: false, reason: 'missing_start_date' };
+    }
+
+    const total = sql`coalesce(sum(${entries.count}), 0)`.mapWith(Number);
+    const dayTotal = sql`coalesce(sum(${entries.count}), 0)`.mapWith(Number);
+    const windowFilter = and(
+        eq(entries.participantId, participants.id),
+        gte(entries.entryDate, window.startDate),
+        lte(entries.entryDate, window.lastDay),
+    );
+
+    const totals = await db
+        .select({ userId: participants.userId, total })
+        .from(participants)
+        .leftJoin(entries, windowFilter)
+        .where(
+            and(
+                eq(participants.guildId, guild.guildId),
+                eq(participants.active, true),
+            ),
+        )
+        .groupBy(participants.userId)
+        .orderBy(desc(total));
+
+    const goalRows = await db
+        .select({
+            userId: participants.userId,
+            entryDate: entries.entryDate,
+            dayTotal,
+        })
+        .from(participants)
+        .innerJoin(entries, windowFilter)
+        .where(
+            and(
+                eq(participants.guildId, guild.guildId),
+                eq(participants.active, true),
+            ),
+        )
+        .groupBy(participants.userId, entries.entryDate);
+
+    const dailyGoalTotal = await getDailyGoalTarget(guild);
+
+    return { ok: true, totals, goalRows, dailyGoalTotal };
+}
+
+export async function markChallengeEnded(guildId) {
+    await db
+        .update(guilds)
+        .set({ challengeEndedAt: new Date() })
+        .where(eq(guilds.guildId, guildId));
+}

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -11,3 +11,4 @@ export * from './participation.js';
 export * from './mutations.js';
 export * from './stats.js';
 export * from './recap.js';
+export * from './challenge-end.js';

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -39,6 +39,13 @@ export const guilds = pgTable('guilds', {
     timezone: text('timezone').notNull().default('Europe/Paris'),
     reminderTime: text('reminder_time').notNull().default('20:00'),
     lastRecapDate: date('last_recap_date'),
+    /**
+     * Marker set once the end-of-challenge message has been posted (#20).
+     * Null = message pas encore posté. Backfill: NULL partout (additif pur).
+     * NOTE (#19): un futur /setup restart devra remettre cette colonne à
+     * NULL pour permettre le message d’un nouveau challenge.
+     */
+    challengeEndedAt: timestamp('challenge_ended_at'),
 });
 
 export const guildExerciseGoals = pgTable(

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -74,6 +74,7 @@ async function sendChallengeEndMessages(client) {
             }
 
             const podiumRows = results.totals
+                .filter((row) => row.total > 0)
                 .slice(0, 3)
                 .map((row, index) =>
                     buildPodiumLine(index + 1, row.userId, row.total),

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -1,9 +1,18 @@
 import cron from 'node-cron';
 import {
+    getChallengeResults,
     getDailyProgress,
     getDueRecapGuilds,
+    getGuildsForChallengeEnd,
+    markChallengeEnded,
     markRecapSent,
 } from './db/queries.js';
+import {
+    buildChallengeEndMessage,
+    buildGoalLines,
+    buildPodiumLine,
+    getChallengeWindow,
+} from './utils/challenge-end.js';
 
 function buildRecapMessage(guild, progress) {
     const lines = progress.rows.map((row) => {
@@ -41,8 +50,63 @@ async function sendDueRecaps(client) {
     }
 }
 
+function groupGoalRowsByUser(goalRows) {
+    const goalRowsByUser = {};
+
+    for (const row of goalRows) {
+        (goalRowsByUser[row.userId] ??= []).push(row);
+    }
+
+    return goalRowsByUser;
+}
+
+async function sendChallengeEndMessages(client) {
+    const dueGuilds = await getGuildsForChallengeEnd();
+
+    for (const guild of dueGuilds) {
+        try {
+            const channel = await client.channels.fetch(guild.trackedChannelId);
+
+            const results = await getChallengeResults(guild);
+
+            if (!results.ok) {
+                continue;
+            }
+
+            const podiumRows = results.totals
+                .slice(0, 3)
+                .map((row, index) =>
+                    buildPodiumLine(index + 1, row.userId, row.total),
+                );
+
+            const goalLines = buildGoalLines(
+                groupGoalRowsByUser(results.goalRows),
+                results.dailyGoalTotal,
+            );
+
+            await channel.send(
+                buildChallengeEndMessage({
+                    window: getChallengeWindow(guild),
+                    podiumRows,
+                    goalLines,
+                }),
+            );
+
+            await markChallengeEnded(guild.guildId);
+        } catch (error) {
+            console.error(
+                `Échec du message de fin pour le serveur ${guild.guildId} :`,
+                error.message,
+            );
+        }
+    }
+}
+
 export function startScheduler(client) {
     cron.schedule('* * * * *', () => {
-        sendDueRecaps(client).catch((error) => console.error(error));
+        sendDueRecaps(client)
+            .catch((error) => console.error(error))
+            .then(() => sendChallengeEndMessages(client))
+            .catch((error) => console.error(error));
     });
 }

--- a/src/utils/challenge-end.js
+++ b/src/utils/challenge-end.js
@@ -1,0 +1,94 @@
+import { DateTime } from 'luxon';
+
+const MEDALS = ['🥇', '🥈', '🥉'];
+
+export function getChallengeWindow(guild) {
+    if (!guild?.startDate) {
+        return null;
+    }
+
+    const lastDay = DateTime.fromISO(guild.startDate, {
+        zone: guild.timezone,
+    })
+        .plus({ days: guild.durationDays - 1 })
+        .toISODate();
+
+    return { startDate: guild.startDate, lastDay };
+}
+
+export function isChallengeEnded(guild, now = DateTime.now()) {
+    if (guild.challengeEndedAt) {
+        return false;
+    }
+
+    const window = getChallengeWindow(guild);
+
+    if (!window) {
+        return false;
+    }
+
+    const today = now.setZone(guild.timezone).toISODate();
+
+    return today > window.lastDay;
+}
+
+function formatCount(count) {
+    return String(count).replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+}
+
+export function buildPodiumLine(rank, userId, total) {
+    const medal = MEDALS[rank - 1] ?? `${rank}.`;
+
+    return `${medal} <@${userId}> — ${formatCount(total)}`;
+}
+
+export function countDaysWithGoalMet(dailyRows, dailyGoalTotal) {
+    const metDates = new Set();
+
+    for (const row of dailyRows) {
+        if ((row.dayTotal ?? 0) >= dailyGoalTotal) {
+            metDates.add(row.entryDate);
+        }
+    }
+
+    return metDates.size;
+}
+
+export function buildGoalLines(goalRowsByUser, dailyGoalTotal) {
+    return Object.entries(goalRowsByUser)
+        .map(([userId, dailyRows]) => ({
+            userId,
+            days: countDaysWithGoalMet(dailyRows, dailyGoalTotal),
+        }))
+        .filter((row) => row.days >= 1)
+        .sort((a, b) => b.days - a.days || a.userId.localeCompare(b.userId))
+        .map(
+            (row) =>
+                `<@${row.userId}> : ${row.days} jour(s) avec objectif atteint`,
+        );
+}
+
+export function buildChallengeEndMessage({ window, podiumRows, goalLines }) {
+    const dateRange = `Du ${window.startDate} au ${window.lastDay}`;
+    const lines = [
+        '🏆 Challenge terminé !',
+        `${dateRange} — merci à tous les participants !`,
+        '',
+    ];
+
+    if (podiumRows.length > 0) {
+        lines.push(
+            'Podium (total toutes épreuves confondues) :',
+            ...podiumRows,
+        );
+    } else {
+        lines.push('Aucune répétition enregistrée pour ce challenge.');
+    }
+
+    if (goalLines.length > 0) {
+        lines.push('');
+        lines.push('Objectifs quotidiens atteints :', ...goalLines);
+    }
+
+    return lines.join('\n');
+}

--- a/test/challenge-end.test.js
+++ b/test/challenge-end.test.js
@@ -1,0 +1,192 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { DateTime } from 'luxon';
+import {
+    buildChallengeEndMessage,
+    buildGoalLines,
+    buildPodiumLine,
+    countDaysWithGoalMet,
+    getChallengeWindow,
+    isChallengeEnded,
+} from '../src/utils/challenge-end.js';
+
+function atUtc(isoDateTime) {
+    return DateTime.fromISO(isoDateTime, { zone: 'utc' });
+}
+
+function tokyoGuild(overrides = {}) {
+    return {
+        startDate: '2026-08-01',
+        durationDays: 30,
+        timezone: 'Asia/Tokyo',
+        challengeEndedAt: null,
+        ...overrides,
+    };
+}
+
+describe('isChallengeEnded', () => {
+    it('renvoie false avant le dernier jour', () => {
+        assert.equal(
+            isChallengeEnded(tokyoGuild(), atUtc('2026-08-10T00:00:00')),
+            false,
+        );
+    });
+
+    it('renvoie false le dernier jour (non fini)', () => {
+        assert.equal(
+            isChallengeEnded(tokyoGuild(), atUtc('2026-08-30T06:00:00')),
+            false,
+        );
+    });
+
+    it('renvoie true le lendemain du dernier jour en timezone guilde', () => {
+        const now = atUtc('2026-08-30T15:30:00');
+
+        assert.equal(now.setZone('utc').toISODate(), '2026-08-30');
+        assert.equal(isChallengeEnded(tokyoGuild(), now), true);
+    });
+
+    it('renvoie true bien après la fin du challenge', () => {
+        assert.equal(
+            isChallengeEnded(tokyoGuild(), atUtc('2026-09-20T00:00:00')),
+            true,
+        );
+    });
+
+    it('renvoie false si startDate est null', () => {
+        assert.equal(
+            isChallengeEnded(
+                tokyoGuild({ startDate: null }),
+                atUtc('2026-09-20T00:00:00'),
+            ),
+            false,
+        );
+    });
+
+    it('renvoie false si challengeEndedAt est déjà setté', () => {
+        assert.equal(
+            isChallengeEnded(
+                tokyoGuild({
+                    challengeEndedAt: atUtc('2026-09-01T00:00:00').toJSDate(),
+                }),
+                atUtc('2026-09-20T00:00:00'),
+            ),
+            false,
+        );
+    });
+
+    it('utilise DateTime.now() par défaut et ne throw pas', () => {
+        assert.equal(typeof isChallengeEnded(tokyoGuild()), 'boolean');
+    });
+});
+
+describe('getChallengeWindow', () => {
+    it('renvoie null sans startDate', () => {
+        assert.equal(getChallengeWindow(tokyoGuild({ startDate: null })), null);
+    });
+
+    it('calcule lastDay depuis startDate et durationDays', () => {
+        assert.deepEqual(getChallengeWindow(tokyoGuild()), {
+            startDate: '2026-08-01',
+            lastDay: '2026-08-30',
+        });
+    });
+});
+
+describe('countDaysWithGoalMet', () => {
+    it('renvoie 0 sans ligne', () => {
+        assert.equal(countDaysWithGoalMet([], 100), 0);
+    });
+
+    it('ne compte que les jours atteignant le seuil', () => {
+        const dailyRows = [
+            { entryDate: '2026-08-01', dayTotal: 99 },
+            { entryDate: '2026-08-02', dayTotal: 150 },
+        ];
+
+        assert.equal(countDaysWithGoalMet(dailyRows, 100), 1);
+    });
+
+    it('compte chaque date distincte une seule fois', () => {
+        const dailyRows = [
+            { entryDate: '2026-08-01', dayTotal: 100 },
+            { entryDate: '2026-08-01', dayTotal: 200 },
+            { entryDate: '2026-08-02', dayTotal: 300 },
+        ];
+
+        assert.equal(countDaysWithGoalMet(dailyRows, 100), 2);
+    });
+});
+
+describe('buildPodiumLine', () => {
+    it('utilise les médailles pour les rangs 1 à 3', () => {
+        assert.equal(buildPodiumLine(1, '111', 12345), '🥇 <@111> — 12 345');
+        assert.equal(buildPodiumLine(2, '222', 500), '🥈 <@222> — 500');
+        assert.equal(buildPodiumLine(3, '333', 42), '🥉 <@333> — 42');
+    });
+});
+
+describe('buildGoalLines', () => {
+    it('trie par jours décroissants puis userId et ignore N < 1', () => {
+        const goalRowsByUser = {
+            444: [{ entryDate: '2026-08-04', dayTotal: 10 }],
+            222: [
+                { entryDate: '2026-08-01', dayTotal: 100 },
+                { entryDate: '2026-08-02', dayTotal: 120 },
+            ],
+            333: [{ entryDate: '2026-08-03', dayTotal: 100 }],
+            111: [
+                { entryDate: '2026-08-01', dayTotal: 100 },
+                { entryDate: '2026-08-02', dayTotal: 190 },
+                { entryDate: '2026-08-03', dayTotal: 110 },
+            ],
+        };
+
+        assert.deepEqual(buildGoalLines(goalRowsByUser, 100), [
+            '<@111> : 3 jour(s) avec objectif atteint',
+            '<@222> : 2 jour(s) avec objectif atteint',
+            '<@333> : 1 jour(s) avec objectif atteint',
+        ]);
+    });
+});
+
+describe('buildChallengeEndMessage', () => {
+    const window = { startDate: '2026-08-01', lastDay: '2026-08-30' };
+
+    it('construit le message complet avec podium et objectifs', () => {
+        const message = buildChallengeEndMessage({
+            window,
+            podiumRows: ['🥇 <@111> — 1 000', '🥈 <@222> — 900'],
+            goalLines: ['<@111> : 5 jour(s) avec objectif atteint'],
+        });
+
+        assert.ok(message.startsWith('🏆 Challenge terminé !'));
+        assert.ok(message.includes('Du 2026-08-01 au 2026-08-30'));
+        assert.ok(
+            message.includes('Podium (total toutes épreuves confondues) :'),
+        );
+        assert.ok(message.includes('<@111>'));
+        assert.ok(message.includes('<@222>'));
+        assert.ok(message.includes('🥇'));
+        assert.ok(message.includes('🥈'));
+        assert.ok(message.includes('Objectifs quotidiens atteints :'));
+        assert.ok(message.includes('<@111> : 5 jour(s) avec objectif atteint'));
+        assert.ok(!/'/.test(message));
+    });
+
+    it('remplace le bloc podium si aucune entrée', () => {
+        const message = buildChallengeEndMessage({
+            window,
+            podiumRows: [],
+            goalLines: [],
+        });
+
+        assert.ok(
+            message.includes(
+                'Aucune répétition enregistrée pour ce challenge.',
+            ),
+        );
+        assert.ok(!message.includes('Podium'));
+        assert.ok(!message.includes('Objectifs quotidiens'));
+    });
+});


### PR DESCRIPTION
Closes #20

**Ordre de merge (stack) :** master ← #24 ← **#28 (celle-ci est construite dessus)** ← celle-ci. Merger #28 d’abord, puis celle-ci.

## Résumé

Message final de fin de challenge posté exactement une fois par le scheduler :

- **Colonne marqueur additive** : `guilds.challenge_ended_at` (timestamp NULL). Anti-spam : le scheduler tick chaque minute, sans ce marqueur il reposterait le message en boucle. Backfill : NULL partout — purement additif, les guildes existantes ne sont pas affectées.
- **Détection pure et testée** : `src/utils/challenge-end.js` — `isChallengeEnded(guild, now = DateTime.now())` (vrai ssi aujourd’hui > startDate + durationDays − 1 en timezone guilde, faux si le marqueur existe déjà ou si la fenêtre est inconnue), `getChallengeWindow`, `buildPodiumLine` (médailles 🥇🥈🥉), `countDaysWithGoalMet`, `buildGoalLines`, `buildChallengeEndMessage`.
- **Couche DB** : `src/db/challenge-end.js` — `getGuildsForChallengeEnd()` (trackedChannelId non null + marqueur null + startDate non null), `getChallengeResults()` (totaux globaux toutes épreuves pour le podium top 3, lignes journalières par utilisateur pour les objectifs, cible quotidienne = somme des goals per-exercise de #18 avec fallback legacy sur `guilds.dailyGoal`, convention `{ ok, reason }`), `markChallengeEnded()`.
- **Scheduler** (`src/scheduler.js`) : `sendChallengeEndMessages(client)` tourne dans le même tick cron que les recaps ; ordre critique = poster PUIS setter `challenge_ended_at` → exactement UN message par challenge terminé, retry au tick suivant en cas d’échec d’envoi. Aucun message sans tracked channel (filtre SQL).
- **Contenu du message** (FR, apostrophes typographiques) : header 🏆 avec dates de la fenêtre (startDate → lastDay), podium global top 3 en mentions Discord (<@id>), puis jours avec objectif quotidien atteint par participant.

## Choix design

Podium **total global toutes épreuves confondues** (plutôt que par type d’exercice) — plus lisible comme récap final de challenge ; les totaux par type restent disponibles via /leaderboard.

## Déploiement

⚠️ Nécessite un `npm run db:push` au déploiement (colonne nullable additive, gérée non-interactivement par drizzle-kit push).

## Notes

- Les recaps réguliers s’arrêtent déjà après la fenêtre via `isRecapDue` — aucun changement à cette logique.
- Hors scope mais commenté dans le schéma : un futur `/setup restart` (#19) devra remettre `challenge_ended_at` à NULL.

## Tests

- `npm test` : 16/16 verts (nouveaux tests node:test sur la logique pure : fin de challenge en TZ guilde, fenêtre, jours-objectif, formatage podium/message, cas vides)
- `npx eslint .` : 0 erreur
- `node --check` OK sur tous les fichiers touchés