### PR TITLE
feat: streaks of successful days computed on the fly (#21)

### DIFF
--- a/src/commands/challenge/stats.js
+++ b/src/commands/challenge/stats.js
@@ -4,6 +4,7 @@ import {
     getGlobalStats,
     getUserAllStats,
     getUserStats,
+    getUserStreak,
 } from '../../db/queries.js';
 
 const exerciseChoices = Object.values(EXERCISE_TYPES).map((exerciseType) => ({
@@ -19,6 +20,20 @@ function addExerciseOption(command, { required = true } = {}) {
             .setRequired(required)
             .addChoices(...exerciseChoices),
     );
+}
+
+function formatStreakLine(streak) {
+    return `Série : ${streak} ${streak === 1 ? 'jour' : 'jours'}`;
+}
+
+async function getStreakLineOrEmpty(guildId, userId) {
+    const streakResult = await getUserStreak(guildId, userId);
+
+    if (!streakResult.ok) {
+        return null;
+    }
+
+    return formatStreakLine(streakResult.streak);
 }
 
 export const data = new SlashCommandBuilder()
@@ -106,6 +121,15 @@ export async function execute(interaction) {
         });
         lines.push(`TOTAL : ${grandTotal}`);
 
+        const streakLine = await getStreakLineOrEmpty(
+            interaction.guildId,
+            user.id,
+        );
+
+        if (streakLine) {
+            lines.push(streakLine);
+        }
+
         await interaction.reply({
             content: [`Stats de ${user}`, ...lines].join('\n'),
         });
@@ -131,12 +155,20 @@ export async function execute(interaction) {
         return;
     }
 
+    const contentLines = [
+        `Stats ${exerciseType} de ${user}`,
+        `Total: ${result.stats.total}`,
+        `Jours loggés: ${result.stats.loggedDays}`,
+        `Meilleur jour: ${result.stats.bestDay}`,
+    ];
+
+    const streakLine = await getStreakLineOrEmpty(interaction.guildId, user.id);
+
+    if (streakLine) {
+        contentLines.push(streakLine);
+    }
+
     await interaction.reply({
-        content: [
-            `Stats ${exerciseType} de ${user}`,
-            `Total: ${result.stats.total}`,
-            `Jours loggés: ${result.stats.loggedDays}`,
-            `Meilleur jour: ${result.stats.bestDay}`,
-        ].join('\n'),
+        content: contentLines.join('\n'),
     });
 }

--- a/src/db/stats.js
+++ b/src/db/stats.js
@@ -1,7 +1,9 @@
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, sql } from 'drizzle-orm';
+import { DateTime } from 'luxon';
 import { db } from './client.js';
-import { entries, participants } from './schema.js';
-import { getActiveParticipant, isExerciseType } from './helpers.js';
+import { entries, guildExerciseGoals, participants } from './schema.js';
+import { computeStreak } from '../utils/streaks.js';
+import { getActiveParticipant, getGuild, isExerciseType } from './helpers.js';
 
 export async function getLeaderboard(guildId, exerciseType) {
     if (!isExerciseType(exerciseType)) {
@@ -137,4 +139,97 @@ export async function getUserStats(guildId, userId, exerciseType) {
         );
 
     return { ok: true, stats };
+}
+
+/**
+ * Consecutive successful days ending today (or yesterday when today is
+ * not yet successful), bounded by the challenge window. A day is
+ * successful iff every configured exercise type reaches its own goal.
+ */
+export async function getUserStreak(guildId, userId) {
+    const participant = await getActiveParticipant(guildId, userId);
+
+    if (!participant) {
+        return { ok: false, reason: 'not_joined' };
+    }
+
+    const guild = await getGuild(guildId);
+
+    if (!guild) {
+        return { ok: false, reason: 'guild_not_configured' };
+    }
+
+    const goalRows = await db
+        .select({
+            exerciseType: guildExerciseGoals.exerciseType,
+            dailyGoal: guildExerciseGoals.dailyGoal,
+        })
+        .from(guildExerciseGoals)
+        .where(eq(guildExerciseGoals.guildId, guildId));
+
+    // No goals configured => no successful day is even possible.
+    if (goalRows.length === 0) {
+        return { ok: true, streak: 0 };
+    }
+
+    const goalsByType = Object.fromEntries(
+        goalRows.map((row) => [row.exerciseType, row.dailyGoal]),
+    );
+
+    const conditions = [eq(entries.participantId, participant.id)];
+
+    if (guild.startDate) {
+        conditions.push(gte(entries.entryDate, guild.startDate));
+    }
+
+    const rows = await db
+        .select({
+            entryDate: entries.entryDate,
+            exerciseType: entries.exerciseType,
+            count: entries.count,
+        })
+        .from(entries)
+        .where(and(...conditions));
+
+    const entriesByDate = {};
+
+    for (const row of rows) {
+        entriesByDate[row.entryDate] ??= {};
+        entriesByDate[row.entryDate][row.exerciseType] =
+            (entriesByDate[row.entryDate][row.exerciseType] ?? 0) + row.count;
+    }
+
+    const streak = computeStreak({
+        entriesByDate,
+        goalsByType,
+        startDate: guild.startDate,
+        durationDays: guild.durationDays,
+        now: DateTime.now().setZone(guild.timezone),
+    });
+
+    return { ok: true, streak };
+}
+
+export async function getGuildStreaks(guildId) {
+    const activeParticipants = await db
+        .select({ userId: participants.userId })
+        .from(participants)
+        .where(
+            and(
+                eq(participants.guildId, guildId),
+                eq(participants.active, true),
+            ),
+        );
+
+    const streaksByUser = new Map();
+
+    for (const { userId } of activeParticipants) {
+        const result = await getUserStreak(guildId, userId);
+
+        if (result.ok) {
+            streaksByUser.set(userId, result.streak);
+        }
+    }
+
+    return streaksByUser;
 }

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -4,6 +4,7 @@ import {
     getChallengeResults,
     getDailyProgressByType,
     getDueRecapGuilds,
+    getGuildStreaks,
     getGuildsForChallengeEnd,
     markChallengeEnded,
     markRecapSent,
@@ -23,7 +24,7 @@ const exerciseLabels = {
     [EXERCISE_TYPES.RUNNING]: 'COURSE',
 };
 
-function buildRecapMessage(guild, progress) {
+function buildRecapMessage(guild, progress, streaksByUser) {
     const goalsByType = new Map(
         progress.goals.map((goal) => [goal.exerciseType, goal.dailyGoal]),
     );
@@ -48,7 +49,13 @@ function buildRecapMessage(guild, progress) {
             return `${exerciseLabels[exerciseType]} ${count}/${goal} ${status}`;
         });
 
-        return `<@${userId}> — ${parts.join(' · ')}`;
+        const streak = streaksByUser.get(userId) ?? 0;
+        const streakLabel = streak === 1 ? 'jour' : 'jours';
+
+        return [
+            `<@${userId}> — ${parts.join(' · ')}`,
+            `série : ${streak} ${streakLabel}`,
+        ].join('\n');
     });
 
     const lateTag = isRecapLate(guild) ? '(en retard) ' : '';
@@ -66,9 +73,12 @@ async function sendDueRecaps(client) {
             const channel = await client.channels.fetch(guild.trackedChannelId);
 
             const progress = await getDailyProgressByType(guild);
+            const streaksByUser = await getGuildStreaks(guild.guildId);
 
             if (progress.rows.length > 0) {
-                await channel.send(buildRecapMessage(guild, progress));
+                await channel.send(
+                    buildRecapMessage(guild, progress, streaksByUser),
+                );
             }
 
             await markRecapSent(guild.guildId, progress.entryDate);

--- a/src/utils/streaks.js
+++ b/src/utils/streaks.js
@@ -1,0 +1,91 @@
+import { DateTime } from 'luxon';
+
+/**
+ * Pure streak computation for a participant (issue #21).
+ *
+ * A day is successful iff EVERY exercise type configured for the guild
+ * reaches its own goal that day. The streak is the number of consecutive
+ * successful days ending today — or ending yesterday when today is not
+ * (yet) successful, so logging below the goals during the current day
+ * does not break the streak. Days with no entries at all are never
+ * successful and stop the walk.
+ *
+ * The walk is bounded by the challenge window: nothing before
+ * `startDate` and nothing after `startDate + durationDays - 1` counts.
+ *
+ * @param {object} params
+ * @param {Object<string, Object<string, number>>} params.entriesByDate
+ *   Plain object keyed by 'YYYY-MM-DD', each value an object mapping
+ *   exercise type to the total count logged that day, e.g.
+ *   `{ '2026-08-25': { PUSHUP: 100, SQUAT: 50 } }`. Missing keys mean
+ *   nothing was logged that day.
+ * @param {Object<string, number>} params.goalsByType Goals for the
+ *   configured types only, e.g. `{ PUSHUP: 100, SQUAT: 50 }`.
+ * @param {string|null} params.startDate Challenge start 'YYYY-MM-DD' or
+ *   null when the challenge has not started yet.
+ * @param {number|null} params.durationDays Positive integer or null.
+ * @param {DateTime} params.now Guild-timezone aware Luxon DateTime used
+ *   to determine "today".
+ * @returns {number} Streak as an integer >= 0.
+ */
+export function computeStreak({
+    entriesByDate,
+    goalsByType,
+    startDate,
+    durationDays,
+    now,
+}) {
+    // Nothing configured => no successful days possible.
+    if (!goalsByType || Object.keys(goalsByType).length === 0) {
+        return 0;
+    }
+
+    const today = now.toISODate();
+
+    // The challenge window is empty before it starts.
+    if (startDate && today < startDate) {
+        return 0;
+    }
+
+    let lastCountedDay = today;
+
+    if (startDate && Number.isInteger(durationDays) && durationDays > 0) {
+        const challengeLastDay = DateTime.fromISO(startDate, { zone: 'utc' })
+            .plus({ days: durationDays - 1 })
+            .toISODate();
+
+        if (challengeLastDay < lastCountedDay) {
+            lastCountedDay = challengeLastDay;
+        }
+    }
+
+    const isSuccessfulDay = (date) => {
+        const dayEntries = entriesByDate?.[date] ?? {};
+
+        return Object.entries(goalsByType).every(
+            ([exerciseType, goal]) => (dayEntries[exerciseType] ?? 0) >= goal,
+        );
+    };
+
+    // Today counts only once it is already successful; otherwise fall
+    // back to yesterday without breaking the streak. When the challenge
+    // is over, lastCountedDay lies strictly before today and must be a
+    // completed successful day like any other.
+    if (lastCountedDay === today && !isSuccessfulDay(today)) {
+        lastCountedDay = DateTime.fromISO(lastCountedDay, { zone: 'utc' })
+            .minus({ days: 1 })
+            .toISODate();
+    }
+
+    let streak = 0;
+    let cursor = lastCountedDay;
+
+    while ((!startDate || cursor >= startDate) && isSuccessfulDay(cursor)) {
+        streak += 1;
+        cursor = DateTime.fromISO(cursor, { zone: 'utc' })
+            .minus({ days: 1 })
+            .toISODate();
+    }
+
+    return streak;
+}

--- a/test/streaks.test.js
+++ b/test/streaks.test.js
@@ -1,0 +1,244 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { DateTime } from 'luxon';
+import { computeStreak } from '../src/utils/streaks.js';
+
+// Fixed "now" in the guild timezone so tests never depend on the
+// runner's clock or TZ. Today is always 2026-08-26 here.
+const NOW = DateTime.fromISO('2026-08-26T12:00:00', {
+    zone: 'Europe/Paris',
+});
+
+// Builds entriesByDate from { 'YYYY-MM-DD': count } for a single type.
+function singleType(perDay, type = 'PUSHUP') {
+    return Object.fromEntries(
+        Object.entries(perDay).map(([date, count]) => [
+            date,
+            { [type]: count },
+        ]),
+    );
+}
+
+describe('computeStreak', () => {
+    it('returns 0 for a participant with zero entries', () => {
+        const streak = computeStreak({
+            entriesByDate: {},
+            goalsByType: { PUSHUP: 100 },
+            startDate: '2026-08-01',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 0);
+    });
+
+    it('counts today when today is already successful', () => {
+        const streak = computeStreak({
+            entriesByDate: singleType({
+                '2026-08-26': 100,
+                '2026-08-25': 100,
+            }),
+            goalsByType: { PUSHUP: 100 },
+            startDate: '2026-08-01',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 2);
+    });
+
+    it('falls back to yesterday when today is not yet successful', () => {
+        // Today has entries below the goal: the streak must not break,
+        // and must count up to yesterday only.
+        const streak = computeStreak({
+            entriesByDate: singleType({
+                '2026-08-26': 40,
+                '2026-08-25': 100,
+                '2026-08-24': 100,
+            }),
+            goalsByType: { PUSHUP: 100 },
+            startDate: '2026-08-01',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 2);
+    });
+
+    it('also falls back to yesterday when today has no entries', () => {
+        const streak = computeStreak({
+            entriesByDate: singleType({
+                '2026-08-25': 100,
+                '2026-08-24': 100,
+            }),
+            goalsByType: { PUSHUP: 100 },
+            startDate: '2026-08-01',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 2);
+    });
+
+    it('is broken by a gap day with no entries at all', () => {
+        // 2026-08-25 has no entry: only today counts.
+        const streak = computeStreak({
+            entriesByDate: singleType({
+                '2026-08-26': 100,
+                '2026-08-24': 100,
+                '2026-08-23': 100,
+            }),
+            goalsByType: { PUSHUP: 100 },
+            startDate: '2026-08-01',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 1);
+    });
+
+    it('fails a day when one exercise stays below its goal', () => {
+        // SQUAT misses its goal on 2026-08-25 while PUSHUP passes.
+        const streak = computeStreak({
+            entriesByDate: {
+                '2026-08-26': { PUSHUP: 120, SQUAT: 60 },
+                '2026-08-25': { PUSHUP: 120, SQUAT: 30 },
+                '2026-08-24': { PUSHUP: 120, SQUAT: 60 },
+            },
+            goalsByType: { PUSHUP: 100, SQUAT: 50 },
+            startDate: '2026-08-01',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 1);
+    });
+
+    it('requires every configured type to pass each day', () => {
+        const streak = computeStreak({
+            entriesByDate: {
+                '2026-08-26': { PUSHUP: 120, SQUAT: 50 },
+                '2026-08-25': { PUSHUP: 120, SQUAT: 50 },
+                '2026-08-24': { PUSHUP: 120 }, // SQUAT missing entirely
+            },
+            goalsByType: { PUSHUP: 100, SQUAT: 50 },
+            startDate: '2026-08-01',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 2);
+    });
+
+    it('ignores entries before the challenge start date', () => {
+        // Successful every day since 2026-08-14 but the challenge only
+        // started on 2026-08-20: only 20..26 may count.
+        const perDay = {};
+        for (let day = 14; day <= 26; day += 1) {
+            perDay[`2026-08-${String(day).padStart(2, '0')}`] = 100;
+        }
+
+        const streak = computeStreak({
+            entriesByDate: singleType(perDay),
+            goalsByType: { PUSHUP: 100 },
+            startDate: '2026-08-20',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 7);
+    });
+
+    it('returns 0 before the challenge starts', () => {
+        const streak = computeStreak({
+            entriesByDate: singleType({ '2026-08-25': 100 }),
+            goalsByType: { PUSHUP: 100 },
+            startDate: '2026-09-01',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 0);
+    });
+
+    it('ignores successes after startDate + durationDays - 1', () => {
+        // Challenge runs 2026-08-01..2026-08-10 (durationDays: 10).
+        // Successful 2026-08-06..2026-08-12; only up to 08-10 counts.
+        const perDay = {};
+        for (let day = 6; day <= 12; day += 1) {
+            perDay[`2026-08-${String(day).padStart(2, '0')}`] = 100;
+        }
+
+        const streak = computeStreak({
+            entriesByDate: singleType(perDay),
+            goalsByType: { PUSHUP: 100 },
+            startDate: '2026-08-01',
+            durationDays: 10,
+            now: NOW,
+        });
+
+        assert.equal(streak, 5);
+    });
+
+    it('ends at the last challenge day once the challenge is over', () => {
+        // Challenge ended 2026-08-10 and that final day was successful;
+        // entries stopped afterwards but must not matter.
+        const streak = computeStreak({
+            entriesByDate: singleType({
+                '2026-08-10': 100,
+                '2026-08-09': 100,
+            }),
+            goalsByType: { PUSHUP: 100 },
+            startDate: '2026-08-01',
+            durationDays: 10,
+            now: NOW,
+        });
+
+        assert.equal(streak, 2);
+    });
+
+    it('never returns a negative streak', () => {
+        // Today below goal and yesterday missing entirely.
+        const streak = computeStreak({
+            entriesByDate: singleType({ '2026-08-26': 1 }),
+            goalsByType: { PUSHUP: 100 },
+            startDate: '2026-08-01',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 0);
+        assert.ok(streak >= 0);
+    });
+
+    it('works for a single-type guild', () => {
+        const streak = computeStreak({
+            entriesByDate: singleType(
+                {
+                    '2026-08-26': 8,
+                    '2026-08-25': 8,
+                    '2026-08-24': 3,
+                },
+                'RUNNING',
+            ),
+            goalsByType: { RUNNING: 8 },
+            startDate: '2026-08-01',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 2);
+    });
+
+    it('returns 0 when no goals are configured', () => {
+        const streak = computeStreak({
+            entriesByDate: singleType({ '2026-08-26': 100 }),
+            goalsByType: {},
+            startDate: '2026-08-01',
+            durationDays: 30,
+            now: NOW,
+        });
+
+        assert.equal(streak, 0);
+    });
+});


### PR DESCRIPTION
> [!WARNING]
> **PR empilée — cible temporaire `master`.** Cette branche part de la branche LOCALE `feat/issue-19-config-ux-v2` (clone /tmp/issue-19, pas encore poussée au moment de l'ouverture). Dès que #19 est poussée, cette PR doit être retargetée sur `feat/issue-19-config-ux-v2`.

## Merge order
#24 → #28 → #19 → **celle-ci (#21)**

Closes #21

## Résumé

Streaks de « jours réussis » calculés **à la volée** depuis les entries existantes — aucun changement de schema, aucun compteur caché à synchroniser.

Définition (décisions owner #19) : un jour est réussi ssi **tous** les types d'exercices configurés atteignent leur goal respectif (table `guild_exercise_goals`). Streak = jours réussis consécutifs finissant **aujourd'hui**, ou **hier** si today n'est pas encore réussi (compter today seulement s'il l'est déjà ; logger en dessous des goals aujourd'hui ne casse pas la série).

## Changements

- **`src/utils/streaks.js`** : helper pur `computeStreak({ entriesByDate, goalsByType, startDate, durationDays, now })` — zéro I/O, déterministe, boucle bornée par la fenêtre du challenge (`[startDate, startDate + durationDays - 1]`), pas de SQL récursif.
- **`src/db/stats.js`** : `getUserStreak(guildId, userId)` → `{ ok, streak }` / `{ ok, reason: 'not_joined' }` ; `getGuildStreaks(guildId)` → `Map<userId, streak>` pour le recap. Aucune goal configurée ⇒ streak 0.
- **`/stats user`** (avec et sans option exercise) : ligne dédiée `Série : N jour(s)` (singulier/pluriel géré).
- **Recap quotidien** (`src/scheduler.js`) : ligne `série : N jours` sous chaque participant, uniquement dans le message recap.
- **Tests** : `test/streaks.test.js` (14 tests node:test) couvrant zéro entrée, today réussi/pas encore, gap day, un type sous le goal, tous les types requis, bornes startDate/fin de challenge, jamais négatif, guilde mono-type. Script npm `test` ajouté.

## Edge cases couverts

- Participant sans entrées ⇒ 0, jamais négatif
- Jour avec entrées sous les goals casse la streak (jour manquant aussi)
- Rien ne compte avant `startDate`, ni après `startDate + durationDays - 1`

## Vérifications

- `npm test` : 14/14 ✅
- `npx eslint .` : 0 erreur ✅
- `node --check` sur les fichiers modifiés ✅