### PR TITLE
feat: strict /setup + /config command with per-exercise goals (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Built with discord.js v14 (pure ESM, Node >= 22.12), Drizzle ORM and Postgres 17
 
 | Command | Purpose |
 |---|---|
-| `/setup` | Configure the challenge for the server (ManageGuild required) |
+| `/setup` | Configure the challenge: tracked channel, duration, timezone, reminder time and the four per-exercise daily goals (`goal_pushup`, `goal_squat`, `goal_crunch`, `goal_running`) — all options required; refused if a configuration already exists (ManageGuild) |
+| `/config view\|set\|delete` | Inspect the current configuration, adjust a single setting (`set channel\|duration_days\|timezone\|reminder_time\|goal`) or delete it — deleting keeps every participant's history and lets `/setup` run again (ManageGuild) |
 | `/join` / `/leave` | Join or leave the challenge |
 | `/log add\|set` | Log today's reps for an exercise type |
 | `/admin-log add\|remove\|set` | Correct another participant's count (ManageGuild) |
@@ -19,7 +20,8 @@ Built with discord.js v14 (pure ESM, Node >= 22.12), Drizzle ORM and Postgres 17
 | `/leaderboard` | Rankings per exercise type |
 
 Daily recap: posted at the configured time (`reminderTime`, guild timezone) in
-the tracked channel, listing every participant's total against `dailyGoal`.
+the tracked channel, listing every active participant with one line per
+exercise type against that exercise's configured goal.
 
 ## Deployment
 

--- a/src/commands/admin/config.js
+++ b/src/commands/admin/config.js
@@ -1,0 +1,314 @@
+import {
+    ChannelType,
+    MessageFlags,
+    PermissionFlagsBits,
+    SlashCommandBuilder,
+} from 'discord.js';
+import { DateTime } from 'luxon';
+import {
+    EXERCISE_TYPES,
+    getGuild,
+    getGuildGoals,
+    isGuildConfigured,
+    resetGuildConfig,
+    setGuildGoal,
+    updateGuildSettings,
+} from '../../db/queries.js';
+import { reminderTimePattern, resolveTimezoneInput } from './setup.js';
+
+const exerciseChoices = Object.values(EXERCISE_TYPES).map((exerciseType) => ({
+    name: exerciseType,
+    value: exerciseType,
+}));
+
+const notConfiguredMessage =
+    'Le serveur n’est pas configuré. Lance `/setup` d’abord.';
+
+function ephemeral(content) {
+    return { content, flags: MessageFlags.Ephemeral };
+}
+
+export const data = new SlashCommandBuilder()
+    .setName('config')
+    .setDescription('Consulte ou ajuste la configuration du challenge.')
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+    .addSubcommand((subcommand) =>
+        subcommand
+            .setName('view')
+            .setDescription('Affiche la configuration actuelle.'),
+    )
+    .addSubcommandGroup((group) =>
+        group
+            .setName('set')
+            .setDescription('Modifie un réglage du challenge.')
+            .addSubcommand((subcommand) =>
+                subcommand
+                    .setName('channel')
+                    .setDescription('Change le salon des récaps.')
+                    .addChannelOption((option) =>
+                        option
+                            .setName('channel')
+                            .setDescription('Nouveau salon.')
+                            .addChannelTypes(ChannelType.GuildText)
+                            .setRequired(true),
+                    ),
+            )
+            .addSubcommand((subcommand) =>
+                subcommand
+                    .setName('duration_days')
+                    .setDescription('Change la durée du challenge.')
+                    .addIntegerOption((option) =>
+                        option
+                            .setName('days')
+                            .setDescription('Durée en jours.')
+                            .setMinValue(1)
+                            .setRequired(true),
+                    ),
+            )
+            .addSubcommand((subcommand) =>
+                subcommand
+                    .setName('timezone')
+                    .setDescription('Change le fuseau horaire.')
+                    .addStringOption((option) =>
+                        option
+                            .setName('timezone')
+                            .setDescription('Fuseau horaire (nom IANA).')
+                            .setAutocomplete(true)
+                            .setRequired(true),
+                    ),
+            )
+            .addSubcommand((subcommand) =>
+                subcommand
+                    .setName('reminder_time')
+                    .setDescription('Change l’heure du rappel quotidien.')
+                    .addStringOption((option) =>
+                        option
+                            .setName('time')
+                            .setDescription('Heure au format HH:mm.')
+                            .setRequired(true),
+                    ),
+            )
+            .addSubcommand((subcommand) =>
+                subcommand
+                    .setName('goal')
+                    .setDescription('Change l’objectif d’un type d’exercice.')
+                    .addStringOption((option) =>
+                        option
+                            .setName('exercise')
+                            .setDescription('Type d’exercice.')
+                            .setRequired(true)
+                            .addChoices(...exerciseChoices),
+                    )
+                    .addIntegerOption((option) =>
+                        option
+                            .setName('value')
+                            .setDescription('Objectif quotidien.')
+                            .setMinValue(1)
+                            .setRequired(true),
+                    ),
+            ),
+    )
+    .addSubcommand((subcommand) =>
+        subcommand
+            .setName('delete')
+            .setDescription(
+                'Supprime la configuration. L’historique des participants est conservé.',
+            ),
+    );
+
+async function handleView(interaction) {
+    const guild = await getGuild(interaction.guildId);
+
+    if (!isGuildConfigured(guild)) {
+        await interaction.reply(ephemeral(notConfiguredMessage));
+        return;
+    }
+
+    const goals = await getGuildGoals(interaction.guildId);
+
+    const today = DateTime.now().setZone(guild.timezone).toISODate();
+    const endDate = DateTime.fromISO(guild.startDate, {
+        zone: guild.timezone,
+    })
+        .plus({ days: guild.durationDays - 1 })
+        .toISODate();
+    const status = today > endDate ? 'TERMINÉ' : 'ACTIF';
+
+    await interaction.reply({
+        content: [
+            'Configuration du challenge :',
+            `Salon : <#${guild.trackedChannelId}>`,
+            `Durée : ${guild.durationDays} jours (début ${guild.startDate}, fin ${endDate})`,
+            `Fuseau horaire : \`${guild.timezone}\``,
+            `Rappel quotidien : ${guild.reminderTime}`,
+            `Statut : ${status}`,
+            'Objectifs quotidiens :',
+            ...goals.map(
+                (goal) => `- ${goal.exerciseType} : ${goal.dailyGoal}`,
+            ),
+        ].join('\n'),
+        flags: MessageFlags.Ephemeral,
+    });
+}
+
+async function handleSetChannel(interaction) {
+    const channel = interaction.options.getChannel('channel', true);
+    const result = await updateGuildSettings(interaction.guildId, {
+        trackedChannelId: channel.id,
+    });
+
+    if (!result.ok) {
+        await interaction.reply(ephemeral(notConfiguredMessage));
+        return;
+    }
+
+    await interaction.reply(
+        ephemeral(`Salon des récaps mis à jour : ${channel}.`),
+    );
+}
+
+async function handleSetDurationDays(interaction) {
+    const days = interaction.options.getInteger('days', true);
+    const result = await updateGuildSettings(interaction.guildId, {
+        durationDays: days,
+    });
+
+    if (!result.ok) {
+        await interaction.reply(ephemeral(notConfiguredMessage));
+        return;
+    }
+
+    await interaction.reply(
+        ephemeral(`Durée du challenge mise à jour : ${days} jours.`),
+    );
+}
+
+async function handleSetTimezone(interaction) {
+    const timezone = interaction.options.getString('timezone', true);
+    const resolved = resolveTimezoneInput(timezone);
+
+    if (!resolved.ok) {
+        if (resolved.candidates.length > 0) {
+            await interaction.reply({
+                content: [
+                    'Plusieurs fuseaux horaires correspondent à ' +
+                        `\`${timezone}\`. Précise ton choix :`,
+                    ...resolved.candidates.map(
+                        (candidate) => `- \`${candidate}\``,
+                    ),
+                ].join('\n'),
+                flags: MessageFlags.Ephemeral,
+            });
+        } else {
+            await interaction.reply(
+                ephemeral(
+                    `Fuseau horaire invalide : \`${timezone}\`. Utilise un nom IANA comme \`Europe/Paris\`.`,
+                ),
+            );
+        }
+        return;
+    }
+
+    const result = await updateGuildSettings(interaction.guildId, {
+        timezone: resolved.timezone,
+    });
+
+    if (!result.ok) {
+        await interaction.reply(ephemeral(notConfiguredMessage));
+        return;
+    }
+
+    await interaction.reply(
+        ephemeral(`Fuseau horaire mis à jour : \`${resolved.timezone}\`.`),
+    );
+}
+
+async function handleSetReminderTime(interaction) {
+    const time = interaction.options.getString('time', true);
+
+    if (!reminderTimePattern.test(time)) {
+        await interaction.reply(
+            ephemeral(
+                `Heure de rappel invalide : \`${time}\`. Format attendu : \`HH:mm\`.`,
+            ),
+        );
+        return;
+    }
+
+    const result = await updateGuildSettings(interaction.guildId, {
+        reminderTime: time,
+    });
+
+    if (!result.ok) {
+        await interaction.reply(ephemeral(notConfiguredMessage));
+        return;
+    }
+
+    await interaction.reply(
+        ephemeral(`Heure de rappel mise à jour : ${time}.`),
+    );
+}
+
+async function handleSetGoal(interaction) {
+    const exerciseType = interaction.options.getString('exercise', true);
+    const value = interaction.options.getInteger('value', true);
+    const result = await setGuildGoal(interaction.guildId, exerciseType, value);
+
+    if (!result.ok) {
+        await interaction.reply(ephemeral(notConfiguredMessage));
+        return;
+    }
+
+    await interaction.reply(
+        ephemeral(`Objectif ${exerciseType} mis à jour : ${value} par jour.`),
+    );
+}
+
+async function handleSet(interaction) {
+    const setting = interaction.options.getSubcommand();
+
+    if (setting === 'channel') {
+        await handleSetChannel(interaction);
+    } else if (setting === 'duration_days') {
+        await handleSetDurationDays(interaction);
+    } else if (setting === 'timezone') {
+        await handleSetTimezone(interaction);
+    } else if (setting === 'reminder_time') {
+        await handleSetReminderTime(interaction);
+    } else {
+        await handleSetGoal(interaction);
+    }
+}
+
+async function handleDelete(interaction) {
+    const result = await resetGuildConfig(interaction.guildId);
+
+    if (!result.ok) {
+        await interaction.reply(ephemeral(notConfiguredMessage));
+        return;
+    }
+
+    await interaction.reply(
+        ephemeral(
+            'Configuration supprimée. Tu peux recréer un challenge avec `/setup`. L’historique des participants est conservé.',
+        ),
+    );
+}
+
+export async function execute(interaction) {
+    const subcommand = interaction.options.getSubcommand();
+
+    if (interaction.options.getSubcommandGroup() === 'set') {
+        await handleSet(interaction);
+        return;
+    }
+
+    if (subcommand === 'view') {
+        await handleView(interaction);
+        return;
+    }
+
+    await handleDelete(interaction);
+}
+
+export { autocomplete } from './setup.js';

--- a/src/commands/admin/setup.js
+++ b/src/commands/admin/setup.js
@@ -5,7 +5,7 @@ import {
     SlashCommandBuilder,
 } from 'discord.js';
 import { DateTime } from 'luxon';
-import { setupGuild } from '../../db/queries.js';
+import { getGuild, isGuildConfigured, setupGuild } from '../../db/queries.js';
 import {
     reminderTimePattern,
     resolveTimezoneInput,
@@ -26,40 +26,64 @@ export const data = new SlashCommandBuilder()
     )
     .addIntegerOption((option) =>
         option
-            .setName('daily_goal')
-            .setDescription('Objectif quotidien.')
-            .setMinValue(1)
-            .setRequired(false),
-    )
-    .addIntegerOption((option) =>
-        option
             .setName('duration_days')
             .setDescription('Durée du challenge en jours.')
             .setMinValue(1)
-            .setRequired(false),
+            .setRequired(true),
     )
     .addStringOption((option) =>
         option
             .setName('timezone')
             .setDescription('Fuseau horaire du serveur.')
             .setAutocomplete(true)
-            .setRequired(false),
+            .setRequired(true),
     )
     .addStringOption((option) =>
         option
             .setName('reminder_time')
             .setDescription('Heure de rappel, format HH:mm.')
-            .setRequired(false),
+            .setRequired(true),
+    )
+    .addIntegerOption((option) =>
+        option
+            .setName('goal_pushup')
+            .setDescription('Objectif quotidien de pompes.')
+            .setMinValue(1)
+            .setRequired(true),
+    )
+    .addIntegerOption((option) =>
+        option
+            .setName('goal_squat')
+            .setDescription('Objectif quotidien de squats.')
+            .setMinValue(1)
+            .setRequired(true),
+    )
+    .addIntegerOption((option) =>
+        option
+            .setName('goal_crunch')
+            .setDescription('Objectif quotidien de crunchs.')
+            .setMinValue(1)
+            .setRequired(true),
+    )
+    .addIntegerOption((option) =>
+        option
+            .setName('goal_running')
+            .setDescription('Objectif quotidien de course.')
+            .setMinValue(1)
+            .setRequired(true),
     );
 
 export async function execute(interaction) {
     const channel = interaction.options.getChannel('channel', true);
-    const dailyGoal = interaction.options.getInteger('daily_goal') ?? 100;
-    const durationDays = interaction.options.getInteger('duration_days') ?? 30;
-    const timezone =
-        interaction.options.getString('timezone') ?? 'Europe/Paris';
-    const reminderTime =
-        interaction.options.getString('reminder_time') ?? '20:00';
+    const durationDays = interaction.options.getInteger('duration_days', true);
+    const timezone = interaction.options.getString('timezone', true);
+    const reminderTime = interaction.options.getString('reminder_time', true);
+    const goals = {
+        PUSHUP: interaction.options.getInteger('goal_pushup', true),
+        SQUAT: interaction.options.getInteger('goal_squat', true),
+        CRUNCH: interaction.options.getInteger('goal_crunch', true),
+        RUNNING: interaction.options.getInteger('goal_running', true),
+    };
 
     const resolved = resolveTimezoneInput(timezone);
     if (!resolved.ok) {
@@ -92,17 +116,33 @@ export async function execute(interaction) {
         return;
     }
 
+    const existingGuild = await getGuild(interaction.guildId);
+
+    if (isGuildConfigured(existingGuild)) {
+        await interaction.reply({
+            content:
+                'Un challenge existe déjà sur ce serveur. Supprime-le avec `/config delete` avant d’en recréer un.',
+            flags: MessageFlags.Ephemeral,
+        });
+        return;
+    }
+
     await setupGuild({
         guildId: interaction.guildId,
         trackedChannelId: channel.id,
-        dailyGoal,
         durationDays,
         timezone: normalizedTimezone,
         reminderTime,
+        goals,
     });
 
     await interaction.reply({
-        content: `Challenge configuré dans ${channel}. Objectif: ${dailyGoal}/jour pendant ${durationDays} jours.`,
+        content: [
+            `Challenge configuré dans ${channel} pendant ${durationDays} jours.`,
+            `Fuseau horaire : \`${normalizedTimezone}\`. Rappel quotidien à ${reminderTime}.`,
+            `Objectifs — POMPES : ${goals.PUSHUP}, SQUATS : ${goals.SQUAT}, ` +
+                `CRUNCH : ${goals.CRUNCH}, COURSE : ${goals.RUNNING}.`,
+        ].join('\n'),
         flags: MessageFlags.Ephemeral,
     });
 }

--- a/src/commands/challenge/log.js
+++ b/src/commands/challenge/log.js
@@ -85,7 +85,7 @@ export async function execute(interaction) {
     }
 
     const congrats = result.reachedGoal
-        ? ` Objectif de ${result.guild.dailyGoal} atteint, bravo !`
+        ? ` Objectif de ${result.goal} ${exerciseType} atteint, bravo !`
         : '';
 
     await interaction.reply({

--- a/src/db/helpers.js
+++ b/src/db/helpers.js
@@ -32,6 +32,10 @@ export function dateInGuildTimezone(guild) {
     return DateTime.now().setZone(guild.timezone).toISODate();
 }
 
+export function isGuildConfigured(guild) {
+    return Boolean(guild?.startDate);
+}
+
 export async function getActiveParticipant(guildId, userId) {
     const [participant] = await db
         .select()

--- a/src/db/mutations.js
+++ b/src/db/mutations.js
@@ -7,7 +7,9 @@ import {
     getGuild,
     getOrCreateEntry,
     isExerciseType,
+    isGuildConfigured,
 } from './helpers.js';
+import { getGuildGoal } from './participation.js';
 
 async function applyExerciseChange({
     guildId,
@@ -23,7 +25,7 @@ async function applyExerciseChange({
 
     const guild = await getGuild(guildId);
 
-    if (!guild) {
+    if (!isGuildConfigured(guild)) {
         return { ok: false, reason: 'guild_not_configured' };
     }
 
@@ -39,6 +41,8 @@ async function applyExerciseChange({
         entryDate,
         exerciseType,
     );
+
+    const exerciseGoal = await getGuildGoal(guildId, exerciseType);
 
     // Lock the row so concurrent commands cannot lose updates.
     const { updatedEntry, beforeCount, afterCount } = await db.transaction(
@@ -94,8 +98,11 @@ async function applyExerciseChange({
         entryDate,
         beforeCount,
         afterCount,
+        goal: exerciseGoal,
         reachedGoal:
-            beforeCount < guild.dailyGoal && afterCount >= guild.dailyGoal,
+            exerciseGoal !== null &&
+            beforeCount < exerciseGoal &&
+            afterCount >= exerciseGoal,
     };
 }
 

--- a/src/db/participation.js
+++ b/src/db/participation.js
@@ -1,49 +1,166 @@
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import { db } from './client.js';
-import { guilds, participants } from './schema.js';
-import { getGuild, getParticipant } from './helpers.js';
+import {
+    EXERCISE_TYPES,
+    guildExerciseGoals,
+    guilds,
+    participants,
+} from './schema.js';
+import {
+    getGuild,
+    getParticipant,
+    isExerciseType,
+    isGuildConfigured,
+} from './helpers.js';
+
+const updatableSettingsFields = [
+    'trackedChannelId',
+    'durationDays',
+    'timezone',
+    'reminderTime',
+];
 
 export async function setupGuild({
     guildId,
     trackedChannelId,
-    dailyGoal,
     durationDays,
     timezone,
     reminderTime,
+    goals,
 }) {
-    const values = {
-        guildId,
-        trackedChannelId,
-        startDate: DateTime.now().setZone(timezone).toISODate(),
-        dailyGoal,
-        durationDays,
-        timezone,
-        reminderTime,
-    };
-
-    const [guild] = await db
-        .insert(guilds)
-        .values(values)
-        .onConflictDoUpdate({
-            target: guilds.guildId,
-            set: {
+    return db.transaction(async (tx) => {
+        const [guild] = await tx
+            .insert(guilds)
+            .values({
+                guildId,
                 trackedChannelId,
-                dailyGoal,
+                startDate: DateTime.now().setZone(timezone).toISODate(),
                 durationDays,
                 timezone,
                 reminderTime,
-            },
+            })
+            .returning();
+
+        await tx.insert(guildExerciseGoals).values(
+            Object.values(EXERCISE_TYPES).map((exerciseType) => ({
+                guildId,
+                exerciseType,
+                dailyGoal: goals[exerciseType],
+            })),
+        );
+
+        return guild;
+    });
+}
+
+export async function updateGuildSettings(guildId, fields) {
+    const guild = await getGuild(guildId);
+
+    if (!isGuildConfigured(guild)) {
+        return { ok: false, reason: 'not_configured' };
+    }
+
+    const updates = {};
+
+    for (const field of updatableSettingsFields) {
+        if (fields[field] !== undefined) {
+            updates[field] = fields[field];
+        }
+    }
+
+    if (Object.keys(updates).length === 0) {
+        return { ok: false, reason: 'no_fields' };
+    }
+
+    const [updatedGuild] = await db
+        .update(guilds)
+        .set(updates)
+        .where(eq(guilds.guildId, guildId))
+        .returning();
+
+    return { ok: true, guild: updatedGuild };
+}
+
+export async function resetGuildConfig(guildId) {
+    const guild = await getGuild(guildId);
+
+    if (!isGuildConfigured(guild)) {
+        return { ok: false, reason: 'not_configured' };
+    }
+
+    await db.transaction(async (tx) => {
+        await tx
+            .update(guilds)
+            .set({
+                trackedChannelId: null,
+                startDate: null,
+                lastRecapDate: null,
+            })
+            .where(eq(guilds.guildId, guildId));
+
+        await tx
+            .delete(guildExerciseGoals)
+            .where(eq(guildExerciseGoals.guildId, guildId));
+    });
+
+    return { ok: true };
+}
+
+export async function getGuildGoals(guildId) {
+    const goals = await db
+        .select()
+        .from(guildExerciseGoals)
+        .where(eq(guildExerciseGoals.guildId, guildId))
+        .orderBy(guildExerciseGoals.exerciseType);
+
+    return goals;
+}
+
+export async function getGuildGoal(guildId, exerciseType) {
+    const [goal] = await db
+        .select({ dailyGoal: guildExerciseGoals.dailyGoal })
+        .from(guildExerciseGoals)
+        .where(
+            and(
+                eq(guildExerciseGoals.guildId, guildId),
+                eq(guildExerciseGoals.exerciseType, exerciseType),
+            ),
+        );
+
+    return goal ? goal.dailyGoal : null;
+}
+
+export async function setGuildGoal(guildId, exerciseType, dailyGoal) {
+    if (!isExerciseType(exerciseType)) {
+        return { ok: false, reason: 'invalid_exercise_type' };
+    }
+
+    const guild = await getGuild(guildId);
+
+    if (!isGuildConfigured(guild)) {
+        return { ok: false, reason: 'not_configured' };
+    }
+
+    const [goal] = await db
+        .insert(guildExerciseGoals)
+        .values({ guildId, exerciseType, dailyGoal })
+        .onConflictDoUpdate({
+            target: [
+                guildExerciseGoals.guildId,
+                guildExerciseGoals.exerciseType,
+            ],
+            set: { dailyGoal },
         })
         .returning();
 
-    return guild;
+    return { ok: true, goal };
 }
 
 export async function joinChallenge(guildId, userId) {
     const guild = await getGuild(guildId);
 
-    if (!guild) {
+    if (!isGuildConfigured(guild)) {
         return { ok: false, reason: 'guild_not_configured' };
     }
 

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -6,6 +6,7 @@ export {
     getOrCreateEntry,
     getParticipant,
     isExerciseType,
+    isGuildConfigured,
 } from './helpers.js';
 export * from './participation.js';
 export * from './mutations.js';

--- a/src/db/recap.js
+++ b/src/db/recap.js
@@ -1,7 +1,8 @@
-import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
+import { and, eq, isNotNull, sql } from 'drizzle-orm';
 import { db } from './client.js';
 import { entries, guilds, participants } from './schema.js';
 import { dateInGuildTimezone } from './helpers.js';
+import { getGuildGoals } from './participation.js';
 import { isRecapDue } from '../utils/recap-time.js';
 
 export { isRecapDue };
@@ -17,33 +18,37 @@ export async function getDueRecapGuilds() {
     return configuredGuilds.filter((guild) => isRecapDue(guild));
 }
 
-export async function getDailyProgress(guild) {
+export async function getDailyProgressByType(guild) {
     const entryDate = dateInGuildTimezone(guild);
     const total = sql`coalesce(sum(${entries.count}), 0)`.mapWith(Number);
 
-    const rows = await db
-        .select({
-            userId: participants.userId,
-            total,
-        })
-        .from(participants)
-        .leftJoin(
-            entries,
-            and(
-                eq(entries.participantId, participants.id),
-                eq(entries.entryDate, entryDate),
-            ),
-        )
-        .where(
-            and(
-                eq(participants.guildId, guild.guildId),
-                eq(participants.active, true),
-            ),
-        )
-        .groupBy(participants.userId)
-        .orderBy(desc(total));
+    const [goals, rows] = await Promise.all([
+        getGuildGoals(guild.guildId),
+        db
+            .select({
+                userId: participants.userId,
+                exerciseType: entries.exerciseType,
+                total,
+            })
+            .from(participants)
+            .leftJoin(
+                entries,
+                and(
+                    eq(entries.participantId, participants.id),
+                    eq(entries.entryDate, entryDate),
+                ),
+            )
+            .where(
+                and(
+                    eq(participants.guildId, guild.guildId),
+                    eq(participants.active, true),
+                ),
+            )
+            .groupBy(participants.userId, entries.exerciseType)
+            .orderBy(participants.userId),
+    ]);
 
-    return { entryDate, rows };
+    return { entryDate, goals, rows };
 }
 
 export async function markRecapSent(guildId, recapDate) {

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -1,7 +1,8 @@
 import cron from 'node-cron';
 import {
+    EXERCISE_TYPES,
     getChallengeResults,
-    getDailyProgress,
+    getDailyProgressByType,
     getDueRecapGuilds,
     getGuildsForChallengeEnd,
     markChallengeEnded,
@@ -15,14 +16,39 @@ import {
 } from './utils/challenge-end.js';
 import { isRecapLate } from './utils/recap-time.js';
 
-function buildRecapMessage(guild, progress) {
-    const lines = progress.rows.map((row) => {
-        const status =
-            row.total >= guild.dailyGoal
-                ? 'objectif atteint !'
-                : 'objectif non atteint';
+const exerciseLabels = {
+    [EXERCISE_TYPES.PUSHUP]: 'POMPES',
+    [EXERCISE_TYPES.SQUAT]: 'SQUATS',
+    [EXERCISE_TYPES.CRUNCH]: 'CRUNCH',
+    [EXERCISE_TYPES.RUNNING]: 'COURSE',
+};
 
-        return `<@${row.userId}> : ${row.total}/${guild.dailyGoal} — ${status}`;
+function buildRecapMessage(guild, progress) {
+    const goalsByType = new Map(
+        progress.goals.map((goal) => [goal.exerciseType, goal.dailyGoal]),
+    );
+
+    const countsByUser = new Map();
+
+    for (const row of progress.rows) {
+        if (!countsByUser.has(row.userId)) {
+            countsByUser.set(row.userId, new Map());
+        }
+
+        if (row.exerciseType && goalsByType.has(row.exerciseType)) {
+            countsByUser.get(row.userId).set(row.exerciseType, row.total);
+        }
+    }
+
+    const lines = [...countsByUser.entries()].map(([userId, counts]) => {
+        const parts = [...goalsByType.entries()].map(([exerciseType, goal]) => {
+            const count = counts.get(exerciseType) ?? 0;
+            const status = count >= goal ? '✅' : '❌';
+
+            return `${exerciseLabels[exerciseType]} ${count}/${goal} ${status}`;
+        });
+
+        return `<@${userId}> — ${parts.join(' · ')}`;
     });
 
     const lateTag = isRecapLate(guild) ? '(en retard) ' : '';
@@ -39,7 +65,7 @@ async function sendDueRecaps(client) {
         try {
             const channel = await client.channels.fetch(guild.trackedChannelId);
 
-            const progress = await getDailyProgress(guild);
+            const progress = await getDailyProgressByType(guild);
 
             if (progress.rows.length > 0) {
                 await channel.send(buildRecapMessage(guild, progress));

--- a/test/defaults-contract.test.js
+++ b/test/defaults-contract.test.js
@@ -1,6 +1,5 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import {
     entries,
     EXERCISE_TYPES,
@@ -8,65 +7,19 @@ import {
     participants,
 } from '../src/db/schema.js';
 
-// Command fallbacks live as `?? <literal>` in setup's execute(); the schema
-// column defaults live on the drizzle table columns. This contract pins them
-// together so one cannot drift from the other. When #11 extracts src/config.js,
-// both sides of each assertion should switch to importing the shared constant.
+// Contract test pinning the drizzle schema column defaults. Prior to #19 this
+// also pinned command-level `?? <literal>` fallbacks in /setup; those were
+// removed when /setup became all-required, so only the schema side remains.
+// When #11 extracts src/config.js, these defaults should switch to importing
+// the shared constant.
 
-const setupSource = readFileSync(
-    new URL('../src/commands/admin/setup.js', import.meta.url),
-    'utf8',
-);
+// The daily-goal/duration/timezone/reminder command-level `?? <literal>`
+// fallbacks were removed in #19: /setup now makes every option required, so
+// there is no command fallback left to pin against the schema. The schema
+// column defaults are still asserted below (they remain the source of truth
+// for rows created outside the strict command path).
 
-function fallbackLiteral(optionName) {
-    const pattern = new RegExp(
-        String.raw`getString\('${optionName}'\) \?\? '([^']+)';`,
-    );
-    const match = setupSource.match(pattern);
-    assert.ok(match, `no ?? fallback found for option ${optionName}`);
-    return match[1];
-}
-
-function fallbackInteger(optionName) {
-    const pattern = new RegExp(
-        String.raw`getInteger\('${optionName}'\) \?\? (\d+);`,
-    );
-    const match = setupSource.match(pattern);
-    assert.ok(match, `no ?? fallback found for option ${optionName}`);
-    return Number(match[1]);
-}
-
-describe('defaults contract (commands <-> schema)', () => {
-    it('daily_goal fallback equals guilds.dailyGoal default', () => {
-        assert.equal(fallbackInteger('daily_goal'), 100);
-        assert.equal(guilds.dailyGoal.default, 100);
-        assert.equal(fallbackInteger('daily_goal'), guilds.dailyGoal.default);
-    });
-
-    it('duration_days fallback equals guilds.durationDays default', () => {
-        assert.equal(fallbackInteger('duration_days'), 30);
-        assert.equal(guilds.durationDays.default, 30);
-        assert.equal(
-            fallbackInteger('duration_days'),
-            guilds.durationDays.default,
-        );
-    });
-
-    it('timezone fallback equals guilds.timezone default', () => {
-        assert.equal(fallbackLiteral('timezone'), 'Europe/Paris');
-        assert.equal(guilds.timezone.default, 'Europe/Paris');
-        assert.equal(fallbackLiteral('timezone'), guilds.timezone.default);
-    });
-
-    it('reminder_time fallback equals guilds.reminderTime default', () => {
-        assert.equal(fallbackLiteral('reminder_time'), '20:00');
-        assert.equal(guilds.reminderTime.default, '20:00');
-        assert.equal(
-            fallbackLiteral('reminder_time'),
-            guilds.reminderTime.default,
-        );
-    });
-
+describe('defaults contract (schema)', () => {
     it('exercise type default matches EXERCISE_TYPES.PUSHUP', () => {
         assert.equal(entries.exerciseType.hasDefault, true);
         assert.equal(entries.exerciseType.default, EXERCISE_TYPES.PUSHUP);


### PR DESCRIPTION
Closes #19, closes #12 (sémantique tranchée : objectifs par type d’exercice), remplace #14 (restart = `/config delete` + nouveau `/setup`, plus de flag).

**Ordre de merge (stack) :** master ← #24 ← #28 ← celle-ci. Merger #28 d’abord.

## Résumé

### `/setup` v2 — one-shot, tout requis
- 8 options **required** : channel, duration_days, timezone (autocomplete conservé), reminder_time, goal_pushup/squat/crunch/running. Discord refuse nativement s’il manque un param → aucune écriture partielle possible.
- **Garde anti-doublon avant toute écriture** : config existante → éphémère « Un challenge existe déjà sur ce serveur. Supprime-le avec `/config delete` avant d’en recréer un. »
- `setupGuild()` réécrite : transaction INSERT guilds + 4 lignes guild_exercise_goals, plus d’upsert, plus aucun legacy dailyGoal écrit.

### `/config` — view / set ×5 / delete
- `view` : canal, durée, dates début/fin calculées en TZ guilde, fuseau, rappel, statut ACTIF/TERMINÉ, les 4 objectifs.
- `set channel|duration_days|timezone|reminder_time|goal <exercise> <value>` — un champ à la fois, validation timezone/HH:mm réutilisée de setup.js.
- `delete` : **soft reset** — UPDATE guilds (trackedChannelId, startDate, lastRecapDate → NULL) + purge des guild_exercise_goals dans une transaction.

🔴 **Décision design importante** : l’issue disait « drop the guilds row » — c’est un piège. `participants.guild_id` a une FK ON DELETE CASCADE vers guilds : supprimer la ligne aurait **détruit participants → entries → entry_events**, l’inverse exact de l’objectif « history preserved ». Le reset est donc un UPDATE ; la ligne guilds reste comme ancre et la guilde redevient non configurée.

### Gating « config active »
Nouveau helper `isGuildConfigured(guild)` = `Boolean(guild?.startDate)`. Remplace le gating `if (!guild)` dans joinChallenge, applyExerciseChange, updateGuildSettings/resetGuildConfig/setGuildGoal → après un delete, la guilde se comporte comme non configurée partout (`/join` refusé, etc.) alors que sa ligne existe encore.

### Objectifs par exercice
- `/log` : `reachedGoal` calcule contre l’objectif du type loggé (`getGuildGoal`), congrats affiche cet objectif. Plus aucune lecture de `guilds.dailyGoal`.
- Recap quotidien : une ligne par participant avec le détail par type — `<@user> — POMPES 120/100 ✅ · SQUATS 40/50 ❌ · …` (requête groupée userId+exerciseType croisée avec les goals).
- Legacy `guilds.dailyGoal` : colonne physique conservée (@deprecated depuis #18, drop deferred) mais plus jamais lue ni écrite.

## Déploiement

Aucun `db:push` nécessaire (aucun changement de schéma). En revanche `npm run deploy` est requis pour enregistrer la nouvelle commande `/config`.

## Vérifications

- `npx eslint .` : 0 erreur
- `node --check` OK sur les 9 fichiers touchés + import runtime de config.js/setup.js OK (arbre des sous-commandes vérifié via toJSON)
- grep `.dailyGoal` sur src/ : uniquement des usages de la NOUVELLE table guild_exercise_goals (+ définition deprecated dans schema.js) — zéro `guild.dailyGoal` restant